### PR TITLE
Updating HoursOfOperation handlers for Override feature

### DIFF
--- a/aws-connect-hoursofoperation/src/main/java/software/amazon/connect/hoursofoperation/ArnHelper.java
+++ b/aws-connect-hoursofoperation/src/main/java/software/amazon/connect/hoursofoperation/ArnHelper.java
@@ -6,6 +6,7 @@ public class ArnHelper {
 
     private static final String HOURS_OF_OPERATION = "operating-hours";
     private static final String HOURS_OF_OPERATION_ARN_PATTERN = "^arn:aws[-a-z0-9]*:connect:[-a-z0-9]*:[0-9]{12}:instance/[-a-zA-Z0-9]*/operating-hours/[-a-zA-Z0-9]*$";
+    private static final String INSTANCE_ARN_PATTERN = "^arn:aws[-a-z0-9]*:connect:[-a-z0-9]*:[0-9]{12}:instance/[-a-zA-Z0-9]*$";
 
     static String getInstanceArnFromHoursOfOperationArn(final String hoursOfOperationArn) {
         return hoursOfOperationArn.substring(0, hoursOfOperationArn.indexOf(HOURS_OF_OPERATION) - 1);
@@ -16,5 +17,12 @@ public class ArnHelper {
             return false;
         }
         return arn.matches(HOURS_OF_OPERATION_ARN_PATTERN);
+    }
+
+    static boolean isValidInstanceArn(final String arn) {
+        if (Objects.isNull(arn)) {
+            return false;
+        }
+        return arn.matches(INSTANCE_ARN_PATTERN);
     }
 }

--- a/aws-connect-hoursofoperation/src/main/java/software/amazon/connect/hoursofoperation/BaseHandlerStd.java
+++ b/aws-connect-hoursofoperation/src/main/java/software/amazon/connect/hoursofoperation/BaseHandlerStd.java
@@ -5,6 +5,9 @@ import org.apache.commons.lang3.StringUtils;
 import software.amazon.awssdk.awscore.AwsRequest;
 import software.amazon.awssdk.awscore.AwsResponse;
 import software.amazon.awssdk.services.connect.ConnectClient;
+import software.amazon.awssdk.services.connect.model.HoursOfOperationOverride;
+import software.amazon.awssdk.services.connect.model.ListHoursOfOperationOverridesRequest;
+import software.amazon.awssdk.services.connect.model.ListHoursOfOperationOverridesResponse;
 import software.amazon.awssdk.services.connect.model.ResourceNotFoundException;
 import software.amazon.awssdk.services.connect.model.InternalServiceException;
 import software.amazon.awssdk.services.connect.model.DuplicateResourceException;
@@ -12,6 +15,9 @@ import software.amazon.awssdk.services.connect.model.LimitExceededException;
 import software.amazon.awssdk.services.connect.model.InvalidRequestException;
 import software.amazon.awssdk.services.connect.model.ConnectException;
 import software.amazon.awssdk.services.connect.model.InvalidParameterException;
+import software.amazon.awssdk.services.connect.model.HoursOfOperationOverrideConfig;
+import software.amazon.awssdk.services.connect.model.OverrideTimeSlice;
+
 import software.amazon.cloudformation.exceptions.CfnAccessDeniedException;
 import software.amazon.cloudformation.exceptions.CfnAlreadyExistsException;
 import software.amazon.cloudformation.exceptions.CfnGeneralServiceException;
@@ -26,6 +32,8 @@ import software.amazon.cloudformation.proxy.ProgressEvent;
 import software.amazon.cloudformation.proxy.ProxyClient;
 import software.amazon.cloudformation.proxy.ResourceHandlerRequest;
 
+import java.util.Collection;
+import java.util.HashSet;
 import java.util.Set;
 import java.util.List;
 import java.util.Map;
@@ -37,8 +45,8 @@ import java.util.stream.Collectors;
 
 public abstract class BaseHandlerStd extends BaseHandler<CallbackContext> {
 
-    private static final String ACCESS_DENIED_ERROR_CODE = "AccessDeniedException";
-    private static final String THROTTLING_ERROR_CODE = "TooManyRequestsException";
+    public static final String ACCESS_DENIED_ERROR_CODE = "AccessDeniedException";
+    public static final String THROTTLING_ERROR_CODE = "TooManyRequestsException";
 
 
     @Override
@@ -97,7 +105,7 @@ public abstract class BaseHandlerStd extends BaseHandler<CallbackContext> {
 
     protected static List<software.amazon.awssdk.services.connect.model.HoursOfOperationConfig> translateToHoursOfOperationConfig(final ResourceModel model) {
         final List<software.amazon.awssdk.services.connect.model.HoursOfOperationConfig> hoursOfOperationConfigList = new ArrayList<>();
-        for (HoursOfOperationConfig hoursOfOperationConfig : model.getConfig()) {
+        for (software.amazon.connect.hoursofoperation.HoursOfOperationConfig hoursOfOperationConfig : model.getConfig()) {
             hoursOfOperationConfigList.add(
                     software.amazon.awssdk.services.connect.model.HoursOfOperationConfig.builder()
                             .startTime(translateToHoursOfOperationTimeSlice(hoursOfOperationConfig.getStartTime()))
@@ -129,5 +137,87 @@ public abstract class BaseHandlerStd extends BaseHandler<CallbackContext> {
                         .map(key -> Tag.builder().key(key).value(resourceTags.get(key)).build())
                         .collect(Collectors.toSet()))
                 .orElse(Sets.newHashSet());
+    }
+
+    public ListHoursOfOperationOverridesResponse listHoursOfOperationOverrides(final ResourceModel model,
+                                                                               final ProxyClient<ConnectClient> proxyClient,
+                                                                               String nextToken) {
+        ListHoursOfOperationOverridesRequest request = ListHoursOfOperationOverridesRequest.builder()
+                .instanceId(ArnHelper.getInstanceArnFromHoursOfOperationArn(model.getHoursOfOperationArn()))
+                .hoursOfOperationId(model.getHoursOfOperationArn())
+                .nextToken(nextToken)
+                .build();
+        return proxyClient.injectCredentialsAndInvokeV2(request, proxyClient.client()::listHoursOfOperationOverrides);
+    }
+
+    protected static List<software.amazon.connect.hoursofoperation.HoursOfOperationOverride> translateToHOOPOverridesList(final List<HoursOfOperationOverride> hoursOfOperationOverrideList) {
+        final List<software.amazon.connect.hoursofoperation.HoursOfOperationOverride> overridesList = new ArrayList<>();
+        for (HoursOfOperationOverride hoursOfOperationOverride : hoursOfOperationOverrideList) {
+            overridesList.add(software.amazon.connect.hoursofoperation.HoursOfOperationOverride.builder()
+                    .hoursOfOperationOverrideId(hoursOfOperationOverride.hoursOfOperationOverrideId())
+                    .overrideName(hoursOfOperationOverride.name())
+                    .overrideDescription(hoursOfOperationOverride.description())
+                    .effectiveFrom(hoursOfOperationOverride.effectiveFrom())
+                    .effectiveTill(hoursOfOperationOverride.effectiveTill())
+                    .overrideConfig(translateFromHOOPOverrideConfigModel(hoursOfOperationOverride))
+                    .build()
+            );
+        }
+        return overridesList;
+    }
+
+    protected static List<HoursOfOperationOverrideConfig> translateToHOOPOverrideConfigModel(final software.amazon.connect.hoursofoperation.HoursOfOperationOverride override) {
+        final List<HoursOfOperationOverrideConfig> overrideConfigModelList = new ArrayList<>();
+        for (software.amazon.connect.hoursofoperation.HoursOfOperationOverrideConfig hoopOverrideConfig : override.getOverrideConfig()) {
+            overrideConfigModelList.add(HoursOfOperationOverrideConfig
+                    .builder()
+                    .startTime(translateToOverrideTimeSliceModel(hoopOverrideConfig.getStartTime()))
+                    .endTime(translateToOverrideTimeSliceModel(hoopOverrideConfig.getEndTime()))
+                    .day(hoopOverrideConfig.getDay())
+                    .build()
+            );
+        }
+        return overrideConfigModelList;
+    }
+
+    protected static Set<software.amazon.connect.hoursofoperation.HoursOfOperationOverrideConfig> translateFromHOOPOverrideConfigModel(final HoursOfOperationOverride hoursOfOperationOverride) {
+        final Set<software.amazon.connect.hoursofoperation.HoursOfOperationOverrideConfig> overrideConfigSet= new HashSet<>();
+        for (HoursOfOperationOverrideConfig hoopOverrideConfig : hoursOfOperationOverride.config()) {
+            overrideConfigSet.add(software.amazon.connect.hoursofoperation.HoursOfOperationOverrideConfig.builder()
+                    .day(hoopOverrideConfig.day().toString())
+                    .startTime(translateFromOverrideTimeSliceModel(hoopOverrideConfig.startTime()))
+                    .endTime(translateFromOverrideTimeSliceModel(hoopOverrideConfig.endTime()))
+                    .build()
+            );
+        }
+        return overrideConfigSet;
+    }
+
+    protected static software.amazon.connect.hoursofoperation.HoursOfOperationOverride translateFromSingleHOOPOverrideModel(final HoursOfOperationOverride override) {
+        Set<software.amazon.connect.hoursofoperation.HoursOfOperationOverrideConfig> overrideConfig = translateFromHOOPOverrideConfigModel(override);
+        return software.amazon.connect.hoursofoperation.HoursOfOperationOverride
+                .builder()
+                .hoursOfOperationOverrideId(override.hoursOfOperationOverrideId())
+                .overrideName(override.name())
+                .overrideDescription(override.description())
+                .overrideConfig(overrideConfig)
+                .effectiveFrom(override.effectiveFrom())
+                .effectiveTill(override.effectiveTill())
+                .build();
+    }
+
+    protected static OverrideTimeSlice translateToOverrideTimeSliceModel(final software.amazon.connect.hoursofoperation
+            .OverrideTimeSlice overrideTime) {
+        return OverrideTimeSlice.builder()
+                .hours(overrideTime.getHours())
+                .minutes(overrideTime.getMinutes())
+                .build();
+    }
+
+    protected static software.amazon.connect.hoursofoperation.OverrideTimeSlice translateFromOverrideTimeSliceModel(final OverrideTimeSlice overrideTime) {
+        return software.amazon.connect.hoursofoperation.OverrideTimeSlice.builder()
+                .hours(overrideTime.hours())
+                .minutes(overrideTime.minutes())
+                .build();
     }
 }

--- a/aws-connect-hoursofoperation/src/main/java/software/amazon/connect/hoursofoperation/CreateHandler.java
+++ b/aws-connect-hoursofoperation/src/main/java/software/amazon/connect/hoursofoperation/CreateHandler.java
@@ -1,17 +1,30 @@
 package software.amazon.connect.hoursofoperation;
 
+import org.apache.commons.lang3.StringUtils;
+import software.amazon.awssdk.awscore.AwsRequestOverrideConfiguration;
 import software.amazon.awssdk.services.connect.ConnectClient;
+import software.amazon.awssdk.services.connect.model.ConnectException;
+import software.amazon.awssdk.services.connect.model.CreateHoursOfOperationOverrideRequest;
+import software.amazon.awssdk.services.connect.model.CreateHoursOfOperationOverrideResponse;
 import software.amazon.awssdk.services.connect.model.CreateHoursOfOperationRequest;
 import software.amazon.awssdk.services.connect.model.CreateHoursOfOperationResponse;
+import software.amazon.cloudformation.exceptions.CfnInvalidRequestException;
 import software.amazon.cloudformation.proxy.ProgressEvent;
 import software.amazon.cloudformation.proxy.AmazonWebServicesClientProxy;
 import software.amazon.cloudformation.proxy.ResourceHandlerRequest;
 import software.amazon.cloudformation.proxy.ProxyClient;
 import software.amazon.cloudformation.proxy.Logger;
+import software.amazon.cloudformation.proxy.delay.Constant;
 
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 public class CreateHandler extends BaseHandlerStd {
+    public static final String RESOURCE_ID_HEADER = "x-amz-resource-id";
 
     @Override
     protected ProgressEvent<ResourceModel, CallbackContext> handleRequest(
@@ -20,17 +33,70 @@ public class CreateHandler extends BaseHandlerStd {
             final CallbackContext callbackContext,
             final ProxyClient<ConnectClient> proxyClient,
             final Logger logger) {
-
         final ResourceModel model = request.getDesiredResourceState();
         final Map<String, String> tags = request.getDesiredResourceTags();
 
-        logger.log(String.format("Invoked CreateHoursOfOperationHandler with InstanceArn:%s ", model.getInstanceArn()));
+        if (model == null) {
+            throw new CfnInvalidRequestException("DesiredResourceState is null, unable to get instanceArn to create HoursOfOperation");
+        }
 
+        logger.log(String.format("Invoked CreateHoursOfOperationHandler with InstanceArn:%s ", model.getInstanceArn()));
+        ProgressEvent<ResourceModel, CallbackContext> hoopProgressEvent = ProgressEvent.progress(request.getDesiredResourceState(), callbackContext)
+                .then(progress -> createHoursOfOperation(proxy, proxyClient, model, tags, callbackContext, logger));
+
+        List<software.amazon.connect.hoursofoperation.HoursOfOperationOverride> overrideList = model.getHoursOfOperationOverrides();
+        if(overrideList != null) {
+            for (int i = 0 ; i < overrideList.size(); i++) {
+                int index = i;
+                hoopProgressEvent = hoopProgressEvent.then(progress -> createHoursOfOperationOverride(proxy, proxyClient,
+                        model, callbackContext, index, overrideList.get(index), logger));
+            }
+        }
+        return hoopProgressEvent.then(progress -> ProgressEvent.defaultSuccessHandler(model));
+    }
+
+    private ProgressEvent<ResourceModel, CallbackContext> createHoursOfOperation(final AmazonWebServicesClientProxy proxy,
+                                                                                 final ProxyClient<ConnectClient> proxyClient,
+                                                                                 final ResourceModel model,
+                                                                                 final Map<String, String> tags,
+                                                                                 final CallbackContext callbackContext,
+                                                                                 final Logger logger){
+        logger.log("Invoking CreateHoursOfOperation operation");
         return proxy.initiate("connect::createHoursOfOperation", proxyClient, model, callbackContext)
                 .translateToServiceRequest(resourceModel -> translateToCreateHoursOfOperationRequest(resourceModel, tags))
                 .makeServiceCall((req, clientProxy) -> invoke(req, clientProxy, clientProxy.client()::createHoursOfOperation, logger))
-                .done(response -> ProgressEvent.defaultSuccessHandler(setHoursOfOperationIdentifier(model, response)));
+                .done(response -> ProgressEvent.progress(setHoursOfOperationIdentifier(model, response), callbackContext));
+    }
 
+    private ProgressEvent<ResourceModel, CallbackContext> createHoursOfOperationOverride(final AmazonWebServicesClientProxy proxy,
+                                                                                         final ProxyClient<ConnectClient> proxyClient,
+                                                                                         final ResourceModel model,
+                                                                                         final CallbackContext callbackContext,
+                                                                                         final int index,
+                                                                                         final HoursOfOperationOverride override,
+                                                                                         final Logger logger) {
+        logger.log("Invoking CreateHoursOfOperationOverride operation");
+        return proxy.initiate("connect::createHoursOfOperationOverride", proxyClient, model, callbackContext)
+                .translateToServiceRequest(resourceModel -> translateToCreateHoursOfOperationOverrideRequest(resourceModel, override, logger))
+                .backoffDelay(Constant.of()
+                        .delay(Duration.ofMillis(500))
+                        .timeout(Duration.ofSeconds(2))
+                        .build())
+                .makeServiceCall((req, clientProxy) -> {
+                    CreateHoursOfOperationOverrideResponse response = null;
+                    try {
+                        response = clientProxy.injectCredentialsAndInvokeV2(req, clientProxy.client()::createHoursOfOperationOverride);
+                    } catch (Exception ex) {
+                        if (isThrottlingException(ex)) {
+                            throw ex;
+                        } else {
+                            handleCommonExceptions(ex, logger);
+                        }
+                    }
+                    return response;
+                })
+                .retryErrorFilter((_req, _ex, _client, _model, _cxt) -> isThrottlingException(_ex))
+                .progress();
     }
 
     private CreateHoursOfOperationRequest translateToCreateHoursOfOperationRequest(final ResourceModel model, final Map<String, String> tags) {
@@ -45,8 +111,35 @@ public class CreateHandler extends BaseHandlerStd {
                 .build();
     }
 
+    private CreateHoursOfOperationOverrideRequest translateToCreateHoursOfOperationOverrideRequest(final ResourceModel model,
+                                                                                                   final HoursOfOperationOverride override,
+                                                                                                   final Logger logger) {
+        logger.log(String.format("Translating request for override id: %s", override.getHoursOfOperationOverrideId()));
+        Map<String, List<String>> overrideHeader = new HashMap<>();
+        if (override.getHoursOfOperationOverrideId() != null) {
+            overrideHeader.put(RESOURCE_ID_HEADER, new ArrayList<>(Collections.singletonList
+                    (override.getHoursOfOperationOverrideId())));
+        }
+        CreateHoursOfOperationOverrideRequest createRequest = CreateHoursOfOperationOverrideRequest.builder()
+                .instanceId(model.getInstanceArn())
+                .hoursOfOperationId(model.getHoursOfOperationArn())
+                .name(override.getOverrideName())
+                .description(override.getOverrideDescription())
+                .effectiveFrom(override.getEffectiveFrom())
+                .effectiveTill(override.getEffectiveTill())
+                .config(translateToHOOPOverrideConfigModel(override))
+                .overrideConfiguration(AwsRequestOverrideConfiguration.builder()
+                        .headers(overrideHeader).build())
+                .build();
+        return createRequest;
+    }
+
     private ResourceModel setHoursOfOperationIdentifier(final ResourceModel model, final CreateHoursOfOperationResponse createHoursOfOperationResponse) {
         model.setHoursOfOperationArn(createHoursOfOperationResponse.hoursOfOperationArn());
         return model;
+    }
+
+    private boolean isThrottlingException(Exception ex) {
+        return (ex instanceof ConnectException && StringUtils.equals(THROTTLING_ERROR_CODE, ((ConnectException) ex).awsErrorDetails().errorCode()));
     }
 }

--- a/aws-connect-hoursofoperation/src/main/java/software/amazon/connect/hoursofoperation/DeleteHandler.java
+++ b/aws-connect-hoursofoperation/src/main/java/software/amazon/connect/hoursofoperation/DeleteHandler.java
@@ -26,7 +26,7 @@ public class DeleteHandler extends BaseHandlerStd {
         logger.log(String.format("Invoked DeleteHoursOfOperationHandler with HoursOfOperationArn:%s", hoursOfOperationArn));
 
         if (!ArnHelper.isValidHoursOfOperationArn(hoursOfOperationArn)) {
-            throw new CfnNotFoundException(new CfnInvalidRequestException(String.format("%s is not a valid Hours Of Operation Arn", hoursOfOperationArn)));
+            throw new CfnNotFoundException(new CfnInvalidRequestException(String.format("The Hours of operation Arn provided in the request is not valid")));
         }
 
         return proxy.initiate("connect::deleteHoursOfOperation", proxyClient, model, callbackContext)

--- a/aws-connect-hoursofoperation/src/main/java/software/amazon/connect/hoursofoperation/ListHandler.java
+++ b/aws-connect-hoursofoperation/src/main/java/software/amazon/connect/hoursofoperation/ListHandler.java
@@ -1,0 +1,79 @@
+package software.amazon.connect.hoursofoperation;
+
+import software.amazon.awssdk.services.connect.ConnectClient;
+import software.amazon.awssdk.services.connect.model.HoursOfOperationSummary;
+import software.amazon.awssdk.services.connect.model.ListHoursOfOperationsRequest;
+import software.amazon.awssdk.services.connect.model.ListHoursOfOperationsResponse;
+import software.amazon.cloudformation.exceptions.CfnInvalidRequestException;
+import software.amazon.cloudformation.proxy.AmazonWebServicesClientProxy;
+import software.amazon.cloudformation.proxy.Logger;
+import software.amazon.cloudformation.proxy.OperationStatus;
+import software.amazon.cloudformation.proxy.ProgressEvent;
+import software.amazon.cloudformation.proxy.ProxyClient;
+import software.amazon.cloudformation.proxy.ResourceHandlerRequest;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+public class ListHandler extends BaseHandlerStd {
+    private Logger logger;
+    private ProxyClient<ConnectClient> proxyClient;
+
+    private static <T> Stream<T> streamOfOrEmpty(final Collection<T> collection) {
+        return Optional.ofNullable(collection)
+                .map(Collection::stream)
+                .orElseGet(Stream::empty);
+
+    }
+
+    @Override
+    public ProgressEvent<ResourceModel, CallbackContext> handleRequest(
+            final AmazonWebServicesClientProxy proxy,
+            final ResourceHandlerRequest<ResourceModel> request,
+            final CallbackContext callbackContext,
+            final ProxyClient<ConnectClient> proxyClient,
+            final Logger logger) {
+        this.logger = logger;
+        this.proxyClient = proxyClient;
+        final ResourceModel model = request.getDesiredResourceState();
+        if (model == null) {
+            throw new CfnInvalidRequestException("DesiredResourceState is null, unable to get instanceArn to list HoursOfOperation");
+        }
+        if (!ArnHelper.isValidInstanceArn(model.getInstanceArn())) {
+            throw new CfnInvalidRequestException(String.format("The instance Arn provided in the request is not valid"));
+        }
+        logger.log(String.format("Invoking HoursOfOperation ListHandler with accountId: %s, instanceArn: %s",
+                request.getAwsAccountId(), model.getInstanceArn()));
+        ListHoursOfOperationsResponse listHoursOfOperationResponse = listHoursOfOperation(request.getNextToken(), model.getInstanceArn());
+        return ProgressEvent.<ResourceModel, CallbackContext>builder()
+                .resourceModels(translateFromListResponse(listHoursOfOperationResponse))
+                .nextToken(listHoursOfOperationResponse.nextToken())
+                .status(OperationStatus.SUCCESS)
+                .build();
+    }
+
+    private ListHoursOfOperationsResponse listHoursOfOperation(String nextToken, String instanceArn) {
+        logger.log(String.format("Invoked listHoursOfOperation operation"));
+        ListHoursOfOperationsRequest request = ListHoursOfOperationsRequest.builder()
+                .nextToken(nextToken)
+                .instanceId(instanceArn)
+                .build();
+        return invoke(request, proxyClient, proxyClient.client()::listHoursOfOperations, logger);
+    }
+
+    private List<ResourceModel> translateFromListResponse(final ListHoursOfOperationsResponse listResponse) {
+        return streamOfOrEmpty(listResponse.hoursOfOperationSummaryList())
+                .map(hoursOfOperationSummary -> translateToResourceModel(hoursOfOperationSummary))
+                .collect(Collectors.toList());
+    }
+
+    private ResourceModel translateToResourceModel(final HoursOfOperationSummary hoursOfOperationSummary) {
+        return ResourceModel.builder()
+                .hoursOfOperationArn(hoursOfOperationSummary.arn())
+                .name(hoursOfOperationSummary.name())
+                .build();
+    }
+}

--- a/aws-connect-hoursofoperation/src/main/java/software/amazon/connect/hoursofoperation/ReadHandler.java
+++ b/aws-connect-hoursofoperation/src/main/java/software/amazon/connect/hoursofoperation/ReadHandler.java
@@ -3,6 +3,11 @@ package software.amazon.connect.hoursofoperation;
 import software.amazon.awssdk.services.connect.ConnectClient;
 import software.amazon.awssdk.services.connect.model.DescribeHoursOfOperationRequest;
 import software.amazon.awssdk.services.connect.model.HoursOfOperation;
+import software.amazon.awssdk.services.connect.model.HoursOfOperationOverride;
+import software.amazon.awssdk.services.connect.model.ListHoursOfOperationOverridesRequest;
+import software.amazon.awssdk.services.connect.model.ListHoursOfOperationOverridesResponse;
+import software.amazon.awssdk.services.connect.model.ConnectException;
+import software.amazon.awssdk.utils.StringUtils;
 import software.amazon.cloudformation.exceptions.CfnInvalidRequestException;
 import software.amazon.cloudformation.exceptions.CfnNotFoundException;
 import software.amazon.cloudformation.proxy.ProgressEvent;
@@ -11,12 +16,13 @@ import software.amazon.cloudformation.proxy.ProxyClient;
 import software.amazon.cloudformation.proxy.Logger;
 import software.amazon.cloudformation.proxy.ResourceHandlerRequest;
 
+import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
-
 public class ReadHandler extends BaseHandlerStd {
+    final ResourceModel model = null;
 
     @Override
     protected ProgressEvent<ResourceModel, CallbackContext> handleRequest(final AmazonWebServicesClientProxy proxy,
@@ -24,20 +30,78 @@ public class ReadHandler extends BaseHandlerStd {
                                                                           final CallbackContext callbackContext,
                                                                           final ProxyClient<ConnectClient> proxyClient,
                                                                           final Logger logger) {
-
         final ResourceModel model = request.getDesiredResourceState();
         final String hoursOfOperationArn = model.getHoursOfOperationArn();
 
         logger.log(String.format("Invoked new ReadHoursOfOperationHandler with HoursOfOperation:%s", hoursOfOperationArn));
 
         if (!ArnHelper.isValidHoursOfOperationArn(hoursOfOperationArn)) {
-            throw new CfnNotFoundException(new CfnInvalidRequestException(String.format("%s is not a valid Hours of operation Arn", hoursOfOperationArn)));
+            throw new CfnNotFoundException(new CfnInvalidRequestException(String.format("The Hours of operation Arn provided in the request is not valid")));
         }
+        return ProgressEvent.progress(request.getDesiredResourceState(), callbackContext)
+                .then(progress -> describeHoursOfOperation(proxy, proxyClient, model, callbackContext, logger))
+                .then(progress -> listHoursOfOperationOverrides(proxy, proxyClient, request, model, callbackContext, logger))
+                .then(progress -> ProgressEvent.defaultSuccessHandler(model));
+    }
 
+    private ProgressEvent<ResourceModel, CallbackContext> describeHoursOfOperation(final AmazonWebServicesClientProxy proxy,
+                                                                                 final ProxyClient<ConnectClient> proxyClient,
+                                                                                 final ResourceModel model,
+                                                                                 final CallbackContext callbackContext,
+                                                                                 final Logger logger){
+        logger.log(String.format("Invoking DescribeHoursOfOperation for HoursOfOperation %s", model.getHoursOfOperationArn()));
         return proxy.initiate("connect::describeHoursOfOperation", proxyClient, model, callbackContext)
                 .translateToServiceRequest(this::translateToDescribeHoursOfOperationRequest)
                 .makeServiceCall((req, clientProxy) -> invoke(req, clientProxy, clientProxy.client()::describeHoursOfOperation, logger))
-                .done(response -> ProgressEvent.defaultSuccessHandler(setHoursOfOperationProperties(model, response.hoursOfOperation())));
+                .done(response -> ProgressEvent.progress(setHoursOfOperationProperties(model, response.hoursOfOperation()), callbackContext));
+    }
+
+    private ProgressEvent<ResourceModel, CallbackContext> listHoursOfOperationOverrides(final AmazonWebServicesClientProxy proxy,
+                                                                                        final ProxyClient<ConnectClient> proxyClient,
+                                                                                        final ResourceHandlerRequest<ResourceModel> request,
+                                                                                        final ResourceModel model,
+                                                                                        final CallbackContext callbackContext,
+                                                                                        final Logger logger){
+        logger.log(String.format("Invoking ListHoursOfOperationOverrides operation for HoursOfOperation %s", model.getHoursOfOperationArn()));
+
+        return proxy.initiate("connect::listHoursOfOperationOverrides", proxyClient, model, callbackContext)
+                .translateToServiceRequest(this::translateToListHoursOfOperationOverridesRequest)
+                .makeServiceCall((req, clientProxy) -> {
+                    List<HoursOfOperationOverride> hoursOfOperationOverrideList = new ArrayList<>();
+                    String nextToken = null;
+                    try {
+                        do {
+                            ListHoursOfOperationOverridesResponse response = listHoursOfOperationOverrides(model, proxyClient, nextToken);
+                            if (response == null || response.hoursOfOperationOverrideList() == null) {
+                                return hoursOfOperationOverrideList;
+                            }
+                            nextToken = response.nextToken();
+                            hoursOfOperationOverrideList.addAll(response.hoursOfOperationOverrideList());
+                        } while (nextToken != null);
+                    } catch (Exception ex) {
+                        if (ex instanceof ConnectException && StringUtils.equals(ACCESS_DENIED_ERROR_CODE, ((ConnectException) ex).awsErrorDetails().errorCode())) {
+                            return null;
+                        } else {
+                            handleCommonExceptions(ex, logger);
+                        }
+                    }
+                    return hoursOfOperationOverrideList;
+                }).done(response -> {
+                    if (response != null) {
+                        return ProgressEvent.progress(setHoursOfOperationOverrides(model, response), callbackContext);
+                    } else {
+                        return ProgressEvent.progress(model, callbackContext);
+                    }
+                });
+    }
+
+    private ListHoursOfOperationOverridesRequest translateToListHoursOfOperationOverridesRequest(final ResourceModel model) {
+        return ListHoursOfOperationOverridesRequest
+                .builder()
+                .instanceId(ArnHelper.getInstanceArnFromHoursOfOperationArn(model.getHoursOfOperationArn()))
+                .hoursOfOperationId(model.getHoursOfOperationArn())
+                .nextToken(null)
+                .build();
     }
 
     private DescribeHoursOfOperationRequest translateToDescribeHoursOfOperationRequest(final ResourceModel model) {
@@ -57,6 +121,11 @@ public class ReadHandler extends BaseHandlerStd {
         model.setTimeZone(hoursOfOperation.timeZone());
         model.setTags(convertResourceTagsToSet(hoursOfOperation.tags()));
         model.setConfig(translateToResourceModelConfig(hoursOfOperation.config()));
+        return model;
+    }
+
+    private ResourceModel setHoursOfOperationOverrides(final ResourceModel model, final List<HoursOfOperationOverride> overrideList) {
+        model.setHoursOfOperationOverrides(translateToHOOPOverridesList(overrideList));
         return model;
     }
 

--- a/aws-connect-hoursofoperation/src/main/java/software/amazon/connect/hoursofoperation/UpdateHandler.java
+++ b/aws-connect-hoursofoperation/src/main/java/software/amazon/connect/hoursofoperation/UpdateHandler.java
@@ -1,10 +1,18 @@
 package software.amazon.connect.hoursofoperation;
 
 import com.google.common.collect.Sets;
+import lombok.Getter;
 import org.apache.commons.lang3.StringUtils;
+import software.amazon.awssdk.awscore.AwsRequestOverrideConfiguration;
 import software.amazon.awssdk.services.connect.ConnectClient;
+import software.amazon.awssdk.services.connect.model.ConnectRequest;
+import software.amazon.awssdk.services.connect.model.CreateHoursOfOperationOverrideRequest;
+import software.amazon.awssdk.services.connect.model.DeleteHoursOfOperationOverrideRequest;
+import software.amazon.awssdk.services.connect.model.HoursOfOperationOverride;
+import software.amazon.awssdk.services.connect.model.ListHoursOfOperationOverridesResponse;
 import software.amazon.awssdk.services.connect.model.TagResourceRequest;
 import software.amazon.awssdk.services.connect.model.UntagResourceRequest;
+import software.amazon.awssdk.services.connect.model.UpdateHoursOfOperationOverrideRequest;
 import software.amazon.awssdk.services.connect.model.UpdateHoursOfOperationRequest;
 import software.amazon.cloudformation.exceptions.CfnInvalidRequestException;
 import software.amazon.cloudformation.proxy.AmazonWebServicesClientProxy;
@@ -13,14 +21,31 @@ import software.amazon.cloudformation.proxy.ProgressEvent;
 import software.amazon.cloudformation.proxy.ProxyClient;
 import software.amazon.cloudformation.proxy.ResourceHandlerRequest;
 
+import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+/**
+ * The updateHandler support update of HoursOfOperation resource and its child entities - HoursOfOperationOverride
+ * This method also supports Sync-service use-case to replicate resources with same resourceId by setting the
+ * resourceId in the header.
+ *
+ *  If the request has Override resourceId in the request, it updates overrides if those overrides exist in database.In case
+ *  the Ids do not match, it creates new overrides.
+ *  If the request does not have Override resourceId, it uses Override name to compare data and follow similar flow to update overrides.
+ *  It also calculates the diff between DesiredModel and PreviousModel and cleanups data that do not exist in desired model.
+ */
 public class UpdateHandler extends BaseHandlerStd {
+    public static final String RESOURCE_ID_HEADER = "x-amz-resource-id";
 
     @Override
     public ProgressEvent<ResourceModel, CallbackContext> handleRequest(
@@ -29,7 +54,6 @@ public class UpdateHandler extends BaseHandlerStd {
             final CallbackContext callbackContext,
             final ProxyClient<ConnectClient> proxyClient,
             final Logger logger) {
-
         final ResourceModel desiredStateModel = request.getDesiredResourceState();
         final ResourceModel previousStateModel = request.getPreviousResourceState();
         final Set<Tag> previousResourceTags = convertResourceTagsToSet(request.getPreviousResourceTags());
@@ -37,17 +61,33 @@ public class UpdateHandler extends BaseHandlerStd {
         final Set<Tag> tagsToRemove = Sets.difference(previousResourceTags, desiredResourceTags);
         final Set<Tag> tagsToAdd = Sets.difference(desiredResourceTags, previousResourceTags);
 
-        logger.log(String.format("Invoked UpdateHoursOfOperationHandler with HoursOfOperation:%s", desiredStateModel.getHoursOfOperationArn()));
-
         if (StringUtils.isNotEmpty(desiredStateModel.getInstanceArn()) && !desiredStateModel.getInstanceArn().equals(previousStateModel.getInstanceArn())) {
             throw new CfnInvalidRequestException("InstanceArn cannot be updated.");
         }
 
-        return ProgressEvent.progress(request.getDesiredResourceState(), callbackContext)
+        if (desiredStateModel.getHoursOfOperationOverrides() == null
+                && !driftDetectedInHoursOfOperation(desiredStateModel, previousStateModel, tagsToAdd, tagsToRemove)) {
+            logger.log(String.format("HoursOfOperationUpdate request has no change from existing state, " +
+                    "skipping update operation for HoursOfOperation:%s", desiredStateModel.getHoursOfOperationArn()));
+            return ProgressEvent.defaultSuccessHandler(desiredStateModel);
+        }
+
+        ProgressEvent<ResourceModel, CallbackContext> hoopProgressEvent = ProgressEvent.progress(request.getDesiredResourceState(), callbackContext)
                 .then(progress -> updateHoursOfOperation(proxy, proxyClient, desiredStateModel, callbackContext, logger))
                 .then(progress -> unTagResource(proxy, proxyClient, desiredStateModel, tagsToRemove, progress, callbackContext, logger))
-                .then(progress -> tagResource(proxy, proxyClient, desiredStateModel, tagsToAdd, progress, callbackContext, logger))
-                .then(progress -> ProgressEvent.defaultSuccessHandler(desiredStateModel));
+                .then(progress -> tagResource(proxy, proxyClient, desiredStateModel, tagsToAdd, progress, callbackContext, logger));
+
+        if (desiredStateModel.getHoursOfOperationOverrides() == null) {
+            return hoopProgressEvent.then(progress -> ProgressEvent.defaultSuccessHandler(desiredStateModel));
+        }
+
+        List<HoursOfOperationOverride> existingOverrides = getExistingHoursOfOperationOverrides(proxyClient, previousStateModel, logger);
+
+        OverrideUpdateOperationResolver overrideUpdateOperationResolver = new OverrideUpdateOperationResolver();
+        overrideUpdateOperationResolver.handleOverrides(proxy, proxyClient, callbackContext,
+                desiredStateModel, existingOverrides, hoopProgressEvent, logger);
+
+        return hoopProgressEvent.then(progress -> ProgressEvent.defaultSuccessHandler(desiredStateModel));
     }
 
     private ProgressEvent<ResourceModel, CallbackContext> updateHoursOfOperation(final AmazonWebServicesClientProxy proxy,
@@ -107,10 +147,37 @@ public class UpdateHandler extends BaseHandlerStd {
         return progress;
     }
 
-    private static <T> Stream<T> streamOfOrEmpty(final Collection<T> collection) {
-        return Optional.ofNullable(collection)
-                .map(Collection::stream)
-                .orElseGet(Stream::empty);
+    private boolean driftDetectedInHoursOfOperation(ResourceModel desiredStateModel,
+                                                    ResourceModel previousStateModel,
+                                                    Set<Tag> tagsToRemove,
+                                                    Set<Tag> tagsToAdd) {
+        // skipping validating the HOOPId as new HOOPs does not have ids
+        boolean sameHoursOfOperation = StringUtils.equals(desiredStateModel.getInstanceArn(), previousStateModel.getInstanceArn())
+                && StringUtils.equals(desiredStateModel.getHoursOfOperationArn(), previousStateModel.getHoursOfOperationArn())
+                && StringUtils.equals(desiredStateModel.getName(), previousStateModel.getName())
+                && StringUtils.equals(desiredStateModel.getDescription(), previousStateModel.getDescription())
+                && StringUtils.equals(desiredStateModel.getTimeZone(), previousStateModel.getTimeZone())
+                && desiredStateModel.getConfig().equals(previousStateModel.getConfig());
+        return !sameHoursOfOperation || !tagsToAdd.isEmpty() || !tagsToRemove.isEmpty();
+    }
+
+    private List<HoursOfOperationOverride> getExistingHoursOfOperationOverrides(
+            final ProxyClient<ConnectClient> proxyClient,
+            final ResourceModel previousStateModel,
+            final Logger logger) {
+        List<HoursOfOperationOverride> hoursOfOperationOverrides = new ArrayList<>();
+        String nextToken = null;
+        logger.log(String.format("Calling ListHoursOfOperationOverrides API for HoursOfOperation: %s",
+                previousStateModel.getHoursOfOperationArn()));
+        do {
+            ListHoursOfOperationOverridesResponse response = listHoursOfOperationOverrides(previousStateModel, proxyClient, nextToken);
+            if (response == null || response.hoursOfOperationOverrideList() == null) {
+                return hoursOfOperationOverrides;
+            }
+            hoursOfOperationOverrides.addAll(response.hoursOfOperationOverrideList());
+            nextToken = response.nextToken();
+        } while (nextToken != null);
+        return hoursOfOperationOverrides;
     }
 
     private UpdateHoursOfOperationRequest translateToUpdateHoursOfOperationRequest(final ResourceModel model) {
@@ -135,6 +202,12 @@ public class UpdateHandler extends BaseHandlerStd {
                 .build();
     }
 
+    private static <T> Stream<T> streamOfOrEmpty(final Collection<T> collection) {
+        return Optional.ofNullable(collection)
+                .map(Collection::stream)
+                .orElseGet(Stream::empty);
+    }
+
     private TagResourceRequest translateToTagRequest(final String hoursOfOperationArn, final Set<Tag> tags) {
         return TagResourceRequest.builder()
                 .resourceArn(hoursOfOperationArn)
@@ -145,5 +218,240 @@ public class UpdateHandler extends BaseHandlerStd {
     private Map<String, String> translateTagsToSdk(final Set<Tag> tags) {
         return tags.stream().collect(Collectors.toMap(Tag::getKey,
                 Tag::getValue));
+    }
+
+    @Getter
+    enum OverrideRequestType {
+        DELETE(0),
+        UPDATE(1),
+        CREATE(2);
+
+        private final int value;
+
+        OverrideRequestType(int value) {
+            this.value = value;
+        }
+    }
+
+    @Getter
+    static class OverrideRequest {
+        private final ConnectRequest request;
+        private final OverrideRequestType requestType;
+
+        public OverrideRequest(ConnectRequest request, OverrideRequestType requestType) {
+            this.request = request;
+            this.requestType = requestType;
+        }
+    }
+
+    static class OverrideUpdateOperationResolver {
+        public void handleOverrides(final AmazonWebServicesClientProxy proxy,
+                                    final ProxyClient<ConnectClient> proxyClient,
+                                    final CallbackContext callbackContext,
+                                    final ResourceModel desiredStateModel,
+                                    List<HoursOfOperationOverride> existingOverrides,
+                                    ProgressEvent<ResourceModel, CallbackContext> hoopProgressEvent,
+                                    final Logger logger) {
+            HoursOfOperationOverrideDriftState overrideDriftState = new HoursOfOperationOverrideDriftState(existingOverrides);
+
+            final List<software.amazon.connect.hoursofoperation.HoursOfOperationOverride> desiredOverridesList = Optional.ofNullable(desiredStateModel
+                    .getHoursOfOperationOverrides()).orElse(new ArrayList<>());
+
+            List<OverrideRequest> overrideRequests = new ArrayList<>();
+            overrideRequests.addAll(desiredOverridesList
+                    .stream()
+                    .map(desiredOverride -> overrideDriftState.generateUpsertOperation(desiredStateModel, desiredOverride))
+                    .filter(Optional::isPresent)
+                    .map(Optional::get)
+                    .collect(Collectors.toList()));
+
+            overrideRequests.addAll(overrideDriftState.generateDeleteOperation(desiredStateModel));
+
+            // sort based on the api-verb, order of preference delete > update > create
+            overrideRequests.sort(Comparator.comparingInt(req -> req.getRequestType().getValue()));
+
+            // Execute Requests
+            overrideRequests
+                    .forEach(request -> processOverrideRequest(proxy, proxyClient, callbackContext, desiredStateModel,
+                            request, hoopProgressEvent, logger));
+        }
+
+        public void processOverrideRequest(final AmazonWebServicesClientProxy proxy,
+                                           final ProxyClient<ConnectClient> proxyClient,
+                                           final CallbackContext callbackContext,
+                                           final ResourceModel desiredStateModel,
+                                           OverrideRequest request,
+                                           ProgressEvent<ResourceModel, CallbackContext> hoopProgressEvent,
+                                           Logger logger) {
+            ConnectRequest req = request.getRequest();
+            switch (request.getRequestType()) {
+                case CREATE:
+                    hoopProgressEvent.then(progress -> createHoursOfOperationOverride(
+                            proxy, proxyClient, desiredStateModel, callbackContext, (CreateHoursOfOperationOverrideRequest) req, logger));
+                    break;
+                case UPDATE:
+                    hoopProgressEvent.then(progress -> updateHoursOfOperationOverride(
+                            proxy, proxyClient, desiredStateModel, callbackContext, (UpdateHoursOfOperationOverrideRequest) req, logger));
+                    break;
+                case DELETE:
+                    hoopProgressEvent.then(progress -> deleteHoursOfOperationOverride(
+                            proxy, proxyClient, desiredStateModel, callbackContext, (DeleteHoursOfOperationOverrideRequest) req, logger));
+                    break;
+            }
+        }
+
+        private ProgressEvent<ResourceModel, CallbackContext> updateHoursOfOperationOverride(final AmazonWebServicesClientProxy proxy,
+                                                                                             final ProxyClient<ConnectClient> proxyClient,
+                                                                                             final ResourceModel desiredStateModel,
+                                                                                             final CallbackContext callbackContext,
+                                                                                             final UpdateHoursOfOperationOverrideRequest updateRequest,
+                                                                                             final Logger logger) {
+            logger.log(String.format("Calling UpdateHoursOfOperationOverride API for HoursOfOperation: %s, HoursOfOperationOverride: %s",
+                    desiredStateModel.getHoursOfOperationArn(), updateRequest.hoursOfOperationOverrideId()));
+            return proxy.initiate("connect::updateHoursOfOperationOverride", proxyClient, desiredStateModel, callbackContext)
+                    .translateToServiceRequest(resourceModel -> updateRequest)
+                    .makeServiceCall((req, clientProxy) -> invoke(req, clientProxy, clientProxy.client()::updateHoursOfOperationOverride, logger))
+                    .done(response -> ProgressEvent.progress(desiredStateModel,callbackContext));
+        }
+
+        private ProgressEvent<ResourceModel, CallbackContext> deleteHoursOfOperationOverride(final AmazonWebServicesClientProxy proxy,
+                                                                                             final ProxyClient<ConnectClient> proxyClient,
+                                                                                             final ResourceModel desiredStateModel,
+                                                                                             final CallbackContext callbackContext,
+                                                                                             final DeleteHoursOfOperationOverrideRequest deleteRequest,
+                                                                                             final Logger logger) {
+            logger.log(String.format("Calling DeleteHoursOfOperationOverride API for HoursOfOperation: %s, HoursOfOperationOverride: %s",
+                    desiredStateModel.getHoursOfOperationArn(), desiredStateModel.getHoursOfOperationOverrides()));
+            return proxy.initiate("connect::deleteHoursOfOperationOverride", proxyClient, desiredStateModel, callbackContext)
+                    .translateToServiceRequest(resourceModel -> deleteRequest)
+                    .makeServiceCall((req, clientProxy) -> invoke(req, clientProxy, clientProxy.client()::deleteHoursOfOperationOverride, logger))
+                    .done(response -> ProgressEvent.progress(desiredStateModel,callbackContext));
+        }
+
+        private ProgressEvent<ResourceModel, CallbackContext> createHoursOfOperationOverride(final AmazonWebServicesClientProxy proxy,
+                                                                                             final ProxyClient<ConnectClient> proxyClient,
+                                                                                             final ResourceModel desiredStateModel,
+                                                                                             final CallbackContext callbackContext,
+                                                                                             final CreateHoursOfOperationOverrideRequest createOverrideRequest,
+                                                                                             final Logger logger) {
+            logger.log(String.format("Calling CreateHoursOfOperationOverride API for HoursOfOperation: %s",
+                    desiredStateModel.getHoursOfOperationArn()));
+            return proxy.initiate("connect::createHoursOfOperationOverride", proxyClient, desiredStateModel, callbackContext)
+                    .translateToServiceRequest(resourceModel -> createOverrideRequest)
+                    .makeServiceCall((req, clientProxy) -> invoke(req, clientProxy, clientProxy.client()::createHoursOfOperationOverride, logger))
+                    .done(response -> ProgressEvent.progress(desiredStateModel, callbackContext));
+        }
+    }
+
+    static class HoursOfOperationOverrideDriftState {
+        Set<HoursOfOperationOverride> overridesRequiringChanges;
+        Map<String, software.amazon.awssdk.services.connect.model.HoursOfOperationOverride> existingOverridesIdMap = new HashMap<>();
+        Map<String, software.amazon.awssdk.services.connect.model.HoursOfOperationOverride> existingOverridesNameMap = new HashMap<>();
+
+        public HoursOfOperationOverrideDriftState(List<software.amazon.awssdk.services.connect.model.HoursOfOperationOverride> existingOverrides) {
+            overridesRequiringChanges = new HashSet<>(existingOverrides);
+            existingOverridesIdMap = overridesRequiringChanges.stream()
+                    .collect(Collectors.toMap(HoursOfOperationOverride::hoursOfOperationOverrideId, override -> override));
+            existingOverridesNameMap = overridesRequiringChanges.stream()
+                    .collect(Collectors.toMap(HoursOfOperationOverride::name, override -> override));
+        }
+
+        public Optional<OverrideRequest> generateUpsertOperation(final ResourceModel desiredStateModel,
+                                                                 final software.amazon.connect.hoursofoperation.HoursOfOperationOverride desiredOverride) {
+            Optional<String> overrideId = Optional.ofNullable(desiredOverride.getHoursOfOperationOverrideId());
+
+            if (overrideId.isPresent()
+                    && existingOverridesIdMap.containsKey(overrideId.get())
+                    && overridesRequiringChanges.contains(existingOverridesIdMap.get(overrideId.get()))) {
+                HoursOfOperationOverride updatedOverride = existingOverridesIdMap.remove(overrideId.get());
+                overridesRequiringChanges.remove(updatedOverride);
+
+                if (noDriftDetectedInOverrides(desiredOverride, translateFromSingleHOOPOverrideModel(updatedOverride))) {
+                    return Optional.empty();
+                }
+                return Optional.of(new OverrideRequest(buildUpdateHoursOfOperationOverrideRequest(desiredStateModel, desiredOverride),
+                        OverrideRequestType.UPDATE));
+            }
+
+            if (!overrideId.isPresent()
+                    && existingOverridesNameMap.containsKey(desiredOverride.getOverrideName())
+                    && overridesRequiringChanges.contains(existingOverridesNameMap.get(desiredOverride.getOverrideName()))) {
+                HoursOfOperationOverride updatedOverride = existingOverridesNameMap.remove(desiredOverride.getOverrideName());
+                overridesRequiringChanges.remove(updatedOverride);
+
+                desiredOverride.setHoursOfOperationOverrideId(updatedOverride.hoursOfOperationOverrideId());
+                if (noDriftDetectedInOverrides(desiredOverride, translateFromSingleHOOPOverrideModel(updatedOverride))) {
+                    return Optional.empty();
+                }
+                return Optional.of(new OverrideRequest(buildUpdateHoursOfOperationOverrideRequest(desiredStateModel, desiredOverride),
+                        OverrideRequestType.UPDATE));
+            }
+
+            return Optional.of(new OverrideRequest(buildCreateHoursOfOperationOverrideRequest(desiredStateModel, desiredOverride),
+                    OverrideRequestType.CREATE));
+        }
+
+        public List<OverrideRequest> generateDeleteOperation(final ResourceModel desiredStateModel) {
+            return overridesRequiringChanges.stream()
+                    .map(overrideToBeDeleted -> buildDeleteHoursOfOperationOverrideRequest(desiredStateModel, overrideToBeDeleted))
+                    .map(connectRequest -> new OverrideRequest(connectRequest, OverrideRequestType.DELETE))
+                    .collect(Collectors.toList());
+        }
+
+        private UpdateHoursOfOperationOverrideRequest buildUpdateHoursOfOperationOverrideRequest(final ResourceModel desiredStateModel,
+                                                                                                 software.amazon.connect.hoursofoperation.HoursOfOperationOverride desiredOverride) {
+            return UpdateHoursOfOperationOverrideRequest.builder()
+                    .instanceId(desiredStateModel.getInstanceArn())
+                    .hoursOfOperationId(desiredStateModel.getHoursOfOperationArn())
+                    .hoursOfOperationOverrideId(desiredOverride.getHoursOfOperationOverrideId())
+                    .name(desiredOverride.getOverrideName())
+                    .description(desiredOverride.getOverrideDescription())
+                    .effectiveFrom(desiredOverride.getEffectiveFrom())
+                    .effectiveTill(desiredOverride.getEffectiveTill())
+                    .config(translateToHOOPOverrideConfigModel(desiredOverride))
+                    .build();
+        }
+
+        private CreateHoursOfOperationOverrideRequest buildCreateHoursOfOperationOverrideRequest(final ResourceModel desiredStateModel,
+                                                                                                 software.amazon.connect.hoursofoperation.HoursOfOperationOverride desiredOverride) {
+            // If request has OverrideId, set the OverrideId in header
+            // If request does not have OverrideId, set empty header so sync-service does not set HOOPId in header
+            Map<String, List<String>> overrideHeader = new HashMap<>();
+            overrideHeader.put(RESOURCE_ID_HEADER, new ArrayList<>(Collections.singletonList("")));
+            if (desiredOverride.getHoursOfOperationOverrideId() != null) {
+                overrideHeader.put(RESOURCE_ID_HEADER, new ArrayList<>(Collections.singletonList
+                        (desiredOverride.getHoursOfOperationOverrideId())));
+            }
+
+            return CreateHoursOfOperationOverrideRequest.builder()
+                    .instanceId(desiredStateModel.getInstanceArn())
+                    .hoursOfOperationId(desiredStateModel.getHoursOfOperationArn())
+                    .name(desiredOverride.getOverrideName())
+                    .description(desiredOverride.getOverrideDescription())
+                    .effectiveFrom(desiredOverride.getEffectiveFrom())
+                    .effectiveTill(desiredOverride.getEffectiveTill())
+                    .config(translateToHOOPOverrideConfigModel(desiredOverride))
+                    .overrideConfiguration(AwsRequestOverrideConfiguration.builder()
+                            .headers(overrideHeader).build())
+                    .build();
+        }
+
+        private ConnectRequest buildDeleteHoursOfOperationOverrideRequest(final ResourceModel model, HoursOfOperationOverride override) {
+            return DeleteHoursOfOperationOverrideRequest.builder()
+                    .instanceId(model.getInstanceArn())
+                    .hoursOfOperationId(model.getHoursOfOperationArn())
+                    .hoursOfOperationOverrideId(override.hoursOfOperationOverrideId())
+                    .build();
+        }
+
+        private Boolean noDriftDetectedInOverrides(software.amazon.connect.hoursofoperation.HoursOfOperationOverride desiredOverride,
+                                                   software.amazon.connect.hoursofoperation.HoursOfOperationOverride existingOverride) {
+            return (Sets.difference(existingOverride.getOverrideConfig(), desiredOverride.getOverrideConfig()).isEmpty()
+                    && StringUtils.equals(desiredOverride.getHoursOfOperationOverrideId(), existingOverride.getHoursOfOperationOverrideId())
+                    && StringUtils.equals(desiredOverride.getOverrideName(), existingOverride.getOverrideName())
+                    && StringUtils.equals(desiredOverride.getOverrideDescription(), existingOverride.getOverrideDescription())
+                    && StringUtils.equals(desiredOverride.getEffectiveFrom(), existingOverride.getEffectiveFrom())
+                    && StringUtils.equals(desiredOverride.getEffectiveTill(), existingOverride.getEffectiveTill()));
+        }
     }
 }

--- a/aws-connect-hoursofoperation/src/test/java/software/amazon/connect/hoursofoperation/HoursOfOperationTestDataProvider.java
+++ b/aws-connect-hoursofoperation/src/test/java/software/amazon/connect/hoursofoperation/HoursOfOperationTestDataProvider.java
@@ -2,8 +2,13 @@ package software.amazon.connect.hoursofoperation;
 
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Sets;
-import software.amazon.awssdk.services.connect.model.HoursOfOperation;
+import org.junit.platform.commons.util.StringUtils;
+import software.amazon.awssdk.services.connect.model.ListHoursOfOperationOverridesResponse;
 
+import java.text.SimpleDateFormat;
+import java.util.Calendar;
+import java.util.Date;
+import java.util.GregorianCalendar;
 import java.util.List;
 import java.util.Set;
 import java.util.HashSet;
@@ -11,6 +16,7 @@ import java.util.Map;
 import java.util.ArrayList;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static software.amazon.connect.hoursofoperation.BaseHandlerStd.translateToHOOPOverrideConfigModel;
 
 public class HoursOfOperationTestDataProvider {
     protected static final String HOURS_OF_OPERATION_ARN = "arn:aws:connect:us-west-2:111111111111:instance/instanceId/operating-hours/hoursOfOperationID";
@@ -22,6 +28,10 @@ public class HoursOfOperationTestDataProvider {
     protected static final String HOURS_OF_OPERATION_DESCRIPTION_ONE = "hoursDescriptionOne";
     protected static final String HOURS_OF_OPERATION_NAME_TWO = "hoursNameTwo";
     protected static final String HOURS_OF_OPERATION_DESCRIPTION_TWO = "hoursDescriptionTwo";
+    protected static final String HOURS_OF_OPERATION_OVERRIDE_DESCRIPTION = "Test description for override";
+    protected static final String HOURS_OF_OPERATION_OVERRIDE_ID_ONE = "hoursOfOperationOverrideIdOne";
+    protected static final String HOURS_OF_OPERATION_OVERRIDE_ID_TWO = "hoursOfOperationOverrideIdTwo";
+    protected static final String HOURS_OF_OPERATION_OVERRIDE_ID_THREE = "hoursOfOperationOverrideIdThree";
     protected static final Integer HOURS_ONE = 12;
     protected static final Integer MINUTES_ONE = 30;
     protected static final Integer HOURS_TWO = 10;
@@ -30,6 +40,8 @@ public class HoursOfOperationTestDataProvider {
     protected static final Integer MINUTES_THREE = 40;
     protected static final String DAY_ONE = "MONDAY";
     protected static final String DAY_TWO = "TUESDAY";
+    protected static final String TUESDAY = "TUESDAY";
+    protected static final String WEDNESDAY = "WEDNESDAY";
     protected static final String DAY_THREE = "WEDNESDAY";
     protected static final String VALID_TAG_KEY_ONE = "TagKeyOne";
     protected static final String TIME_ZONE_ONE = "America/New_York";
@@ -54,6 +66,38 @@ public class HoursOfOperationTestDataProvider {
             .startTime(getHoursOfOperationTimeSLice(HOURS_THREE, MINUTES_THREE))
             .endTime(getHoursOfOperationTimeSLice(HOURS_THREE, MINUTES_THREE))
             .build();
+    public static final String OVERRIDE_NAME_ONE = "create-override-one";
+    public static final String OVERRIDE_NAME_TWO = "create-override-two";
+    public static final String OVERRIDE_NAME_THREE = "create-override-three";
+    public static final Integer OVERRIDE_TIMESLICE_HOUR_9 = 9;
+    public static final Integer OVERRIDE_TIMESLICE_HOUR_17 = 17;
+    public static final Integer OVERRIDE_TIMESLICE_HOUR_15 = 15;
+    public static final Integer OVERRIDE_TIMESLICE_HOUR_13 = 13;
+    public static final Integer OVERRIDE_TIMESLICE_MIN_0 = 0;
+    public static final String NEXT_TOKEN = "12345-67467-765433";
+    private static final Date FROM_DATE = getFromDate(1, 1);
+    private static final Date TILL_DATE = getFromDate(10, 1);
+    public static final String OVERRIDE_EFFECTIVE_FROM = new SimpleDateFormat("yyyy-MM-dd").format(FROM_DATE);
+    public static final String OVERRIDE_EFFECTIVE_TILL = new SimpleDateFormat("yyyy-MM-dd").format(TILL_DATE);
+
+    protected static final HoursOfOperationOverrideConfig HOURS_OF_OPERATION_OVERRIDE_CONFIG_ONE = HoursOfOperationOverrideConfig.builder()
+            .startTime(getOverrideTimeSlice(OVERRIDE_TIMESLICE_HOUR_9, OVERRIDE_TIMESLICE_MIN_0))
+            .endTime(getOverrideTimeSlice(OVERRIDE_TIMESLICE_HOUR_17, OVERRIDE_TIMESLICE_MIN_0))
+            .day(TUESDAY)
+            .build();
+
+    protected static final HoursOfOperationOverrideConfig HOURS_OF_OPERATION_OVERRIDE_CONFIG_TWO = HoursOfOperationOverrideConfig.builder()
+            .startTime(getOverrideTimeSlice(OVERRIDE_TIMESLICE_HOUR_9, OVERRIDE_TIMESLICE_MIN_0))
+            .endTime(getOverrideTimeSlice(OVERRIDE_TIMESLICE_HOUR_15, OVERRIDE_TIMESLICE_MIN_0))
+            .day(WEDNESDAY)
+            .build();
+
+    protected static final HoursOfOperationOverrideConfig HOURS_OF_OPERATION_OVERRIDE_CONFIG_THREE = HoursOfOperationOverrideConfig.builder()
+            .startTime(getOverrideTimeSlice(OVERRIDE_TIMESLICE_HOUR_9, OVERRIDE_TIMESLICE_MIN_0))
+            .endTime(getOverrideTimeSlice(OVERRIDE_TIMESLICE_HOUR_13, OVERRIDE_TIMESLICE_MIN_0))
+            .day(DAY_ONE)
+            .build();
+
     protected static final Map<String, String> TAGS_ONE = ImmutableMap.of(VALID_TAG_KEY_ONE, VALID_TAG_VALUE_ONE);
     protected static final Map<String, String> TAGS_TWO = ImmutableMap.of(VALID_TAG_KEY_THREE, VALID_TAG_VALUE_THREE,
             VALID_TAG_KEY_TWO, VALID_TAG_VALUE_TWO);
@@ -80,6 +124,79 @@ public class HoursOfOperationTestDataProvider {
                 .description(HOURS_OF_OPERATION_DESCRIPTION_TWO)
                 .timeZone(TIME_ZONE_TWO)
                 .config(getConfig(HOURS_OF_OPERATION_CONFIG_TWO, HOURS_OF_OPERATION_CONFIG_THREE))
+                .build();
+    }
+
+    protected static ResourceModel buildHOOPOverridePreviousStateResourceModel() {
+        List<HoursOfOperationOverride> overrides = new ArrayList<>();
+        overrides.add(getOverride(HOURS_OF_OPERATION_OVERRIDE_CONFIG_TWO, HOURS_OF_OPERATION_OVERRIDE_ID_TWO, OVERRIDE_NAME_TWO));
+
+        return ResourceModel.builder()
+                .instanceArn(INSTANCE_ARN)
+                .hoursOfOperationArn(HOURS_OF_OPERATION_ARN)
+                .name(HOURS_OF_OPERATION_NAME_TWO)
+                .description(HOURS_OF_OPERATION_DESCRIPTION_TWO)
+                .timeZone(TIME_ZONE_TWO)
+                .config(getConfig(HOURS_OF_OPERATION_CONFIG_TWO, HOURS_OF_OPERATION_CONFIG_THREE))
+                .hoursOfOperationOverrides(overrides)
+                .build();
+    }
+
+    protected static ResourceModel buildHOOPOverridesPreviousStateResourceModel() {
+        List<HoursOfOperationOverride> overrides = new ArrayList<>();
+        overrides.add(getOverride(HOURS_OF_OPERATION_OVERRIDE_CONFIG_ONE, HOURS_OF_OPERATION_OVERRIDE_ID_ONE, OVERRIDE_NAME_ONE));
+        overrides.add(getOverride(HOURS_OF_OPERATION_OVERRIDE_CONFIG_TWO, HOURS_OF_OPERATION_OVERRIDE_ID_TWO, OVERRIDE_NAME_TWO));
+
+        return ResourceModel.builder()
+                .instanceArn(INSTANCE_ARN)
+                .hoursOfOperationArn(HOURS_OF_OPERATION_ARN)
+                .name(HOURS_OF_OPERATION_NAME_TWO)
+                .description(HOURS_OF_OPERATION_DESCRIPTION_TWO)
+                .timeZone(TIME_ZONE_TWO)
+                .config(getConfig(HOURS_OF_OPERATION_CONFIG_TWO, HOURS_OF_OPERATION_CONFIG_THREE))
+                .hoursOfOperationOverrides(overrides)
+                .build();
+    }
+
+    protected static ResourceModel buildHOOPOverrideDesiredStateResourceModel() {
+        List<HoursOfOperationOverride> overrides = new ArrayList<>();
+        overrides.add(getOverride(HOURS_OF_OPERATION_OVERRIDE_CONFIG_ONE, HOURS_OF_OPERATION_OVERRIDE_ID_ONE, OVERRIDE_NAME_ONE));
+
+        return ResourceModel.builder()
+                .instanceArn(INSTANCE_ARN)
+                .hoursOfOperationArn(HOURS_OF_OPERATION_ARN)
+                .name(HOURS_OF_OPERATION_NAME_ONE)
+                .description(HOURS_OF_OPERATION_DESCRIPTION_ONE)
+                .timeZone(TIME_ZONE_ONE)
+                .config(getConfig(HOURS_OF_OPERATION_CONFIG_ONE, HOURS_OF_OPERATION_CONFIG_TWO))
+                .hoursOfOperationOverrides(overrides)
+                .build();
+    }
+
+    protected static ResourceModel buildHOOPOverrideDesiredStateResourceModelThree() {
+        List<HoursOfOperationOverride> overrides = new ArrayList<>();
+        overrides.add(getOverride(HOURS_OF_OPERATION_OVERRIDE_CONFIG_THREE, HOURS_OF_OPERATION_OVERRIDE_ID_THREE, OVERRIDE_NAME_THREE));
+
+        return ResourceModel.builder()
+                .instanceArn(INSTANCE_ARN)
+                .hoursOfOperationArn(HOURS_OF_OPERATION_ARN)
+                .name(HOURS_OF_OPERATION_NAME_ONE)
+                .description(HOURS_OF_OPERATION_DESCRIPTION_ONE)
+                .timeZone(TIME_ZONE_ONE)
+                .config(getConfig(HOURS_OF_OPERATION_CONFIG_ONE, HOURS_OF_OPERATION_CONFIG_TWO))
+                .hoursOfOperationOverrides(overrides)
+                .build();
+    }
+
+    protected static ResourceModel buildHOOPEmptyOverrideDesiredStateResourceModel() {
+        return ResourceModel.builder()
+                .instanceArn(INSTANCE_ARN)
+                .hoursOfOperationArn(HOURS_OF_OPERATION_ARN)
+                .name(HOURS_OF_OPERATION_NAME_ONE)
+                .description(HOURS_OF_OPERATION_DESCRIPTION_ONE)
+                .timeZone(TIME_ZONE_ONE)
+                .config(getConfig(HOURS_OF_OPERATION_CONFIG_ONE, HOURS_OF_OPERATION_CONFIG_TWO))
+                .hoursOfOperationOverrides(new ArrayList<>())
                 .build();
     }
 
@@ -111,6 +228,66 @@ public class HoursOfOperationTestDataProvider {
         return hoursOfOperationConfigSet;
     }
 
+    public static HoursOfOperationOverride getOverride(final HoursOfOperationOverrideConfig overrideConfig, String overrideId, String OverrideName) {
+        Set<HoursOfOperationOverrideConfig> configSet = new HashSet<>();
+        configSet.add(overrideConfig);
+
+        return HoursOfOperationOverride.builder()
+                .hoursOfOperationOverrideId(overrideId)
+                .overrideName(OverrideName)
+                .overrideDescription(HOURS_OF_OPERATION_OVERRIDE_DESCRIPTION)
+                .overrideConfig(configSet)
+                .effectiveFrom(OVERRIDE_EFFECTIVE_FROM)
+                .effectiveTill(OVERRIDE_EFFECTIVE_TILL)
+                .build();
+    }
+
+    public static software.amazon.awssdk.services.connect.model.HoursOfOperationOverride getHoursOfOperationOverrideThree() {
+        return software.amazon.awssdk.services.connect.model.HoursOfOperationOverride.builder()
+                .hoursOfOperationId(HOURS_OF_OPERATION_ARN)
+                .hoursOfOperationOverrideId(HOURS_OF_OPERATION_OVERRIDE_ID_THREE)
+                .name(OVERRIDE_NAME_THREE)
+                .description(HOURS_OF_OPERATION_OVERRIDE_DESCRIPTION)
+                .effectiveFrom(OVERRIDE_EFFECTIVE_FROM)
+                .effectiveTill(OVERRIDE_EFFECTIVE_TILL)
+                .config(translateToHOOPOverrideConfigModel(getOverride(HOURS_OF_OPERATION_OVERRIDE_CONFIG_THREE, HOURS_OF_OPERATION_OVERRIDE_ID_THREE, OVERRIDE_NAME_THREE)))
+                .build();
+    }
+
+    public static software.amazon.awssdk.services.connect.model.HoursOfOperationOverride getHoursOfOperationOverrideTwo() {
+        return software.amazon.awssdk.services.connect.model.HoursOfOperationOverride.builder()
+                .hoursOfOperationId(HOURS_OF_OPERATION_ARN)
+                .hoursOfOperationOverrideId(HOURS_OF_OPERATION_OVERRIDE_ID_TWO)
+                .name(OVERRIDE_NAME_TWO)
+                .description(HOURS_OF_OPERATION_OVERRIDE_DESCRIPTION)
+                .effectiveFrom(OVERRIDE_EFFECTIVE_FROM)
+                .effectiveTill(OVERRIDE_EFFECTIVE_TILL)
+                .config(translateToHOOPOverrideConfigModel(getOverride(HOURS_OF_OPERATION_OVERRIDE_CONFIG_TWO, HOURS_OF_OPERATION_OVERRIDE_ID_TWO, OVERRIDE_NAME_TWO)))
+                .build();
+    }
+
+    public static software.amazon.awssdk.services.connect.model.HoursOfOperationOverride getHoursOfOperationOverrideOne() {
+        return software.amazon.awssdk.services.connect.model.HoursOfOperationOverride.builder()
+                .hoursOfOperationId(HOURS_OF_OPERATION_ARN)
+                .hoursOfOperationOverrideId(HOURS_OF_OPERATION_OVERRIDE_ID_ONE)
+                .name(OVERRIDE_NAME_ONE)
+                .description(HOURS_OF_OPERATION_OVERRIDE_DESCRIPTION)
+                .effectiveFrom(OVERRIDE_EFFECTIVE_FROM)
+                .effectiveTill(OVERRIDE_EFFECTIVE_TILL)
+                .config(translateToHOOPOverrideConfigModel(getOverride(HOURS_OF_OPERATION_OVERRIDE_CONFIG_ONE, HOURS_OF_OPERATION_OVERRIDE_ID_ONE, OVERRIDE_NAME_ONE)))
+                .build();
+    }
+
+    public static ListHoursOfOperationOverridesResponse getListHOOPOverridesResponse(String nextToken,
+                                                                                     software.amazon.awssdk.services.connect.model.HoursOfOperationOverride override) {
+        ListHoursOfOperationOverridesResponse.Builder builder = ListHoursOfOperationOverridesResponse.builder();
+        builder.hoursOfOperationOverrideList(override);
+        if (StringUtils.isNotBlank(nextToken)) {
+            builder.nextToken(nextToken);
+        }
+        return builder.build();
+    }
+
     protected static void validateConfig(final List<software.amazon.awssdk.services.connect.model.HoursOfOperationConfig> hoursOfOperationConfig) {
         int index = 0;
         for (software.amazon.connect.hoursofoperation.HoursOfOperationConfig config : getConfig(HOURS_OF_OPERATION_CONFIG_ONE, HOURS_OF_OPERATION_CONFIG_TWO)) {
@@ -130,9 +307,23 @@ public class HoursOfOperationTestDataProvider {
                 .build();
     }
 
+    private static OverrideTimeSlice getOverrideTimeSlice(final int hours, final int minutes) {
+        return OverrideTimeSlice.builder()
+                .hours(hours)
+                .minutes(minutes)
+                .build();
+    }
+
     private static Set<Tag> convertTagMapToSet() {
         Set<Tag> tags = Sets.newHashSet();
         TAGS_ONE.forEach((key, value) -> tags.add(Tag.builder().key(key).value(value).build()));
         return tags;
+    }
+
+    private static Date getFromDate(int fromDays, int year) {
+        Calendar calendar = new GregorianCalendar();
+        calendar.add(Calendar.YEAR, year);
+        calendar.add(Calendar.DATE, fromDays);
+        return calendar.getTime();
     }
 }

--- a/aws-connect-hoursofoperation/src/test/java/software/amazon/connect/hoursofoperation/ListHandlerTest.java
+++ b/aws-connect-hoursofoperation/src/test/java/software/amazon/connect/hoursofoperation/ListHandlerTest.java
@@ -1,0 +1,138 @@
+package software.amazon.connect.hoursofoperation;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.platform.commons.util.StringUtils;
+import org.mockito.ArgumentCaptor;
+import software.amazon.awssdk.services.connect.ConnectClient;
+import software.amazon.awssdk.services.connect.model.HoursOfOperationSummary;
+import software.amazon.awssdk.services.connect.model.ListHoursOfOperationsRequest;
+import software.amazon.awssdk.services.connect.model.ListHoursOfOperationsResponse;
+import software.amazon.cloudformation.exceptions.CfnGeneralServiceException;
+import software.amazon.cloudformation.exceptions.CfnInvalidRequestException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import software.amazon.cloudformation.proxy.AmazonWebServicesClientProxy;
+import software.amazon.cloudformation.proxy.Credentials;
+import software.amazon.cloudformation.proxy.LoggerProxy;
+import software.amazon.cloudformation.proxy.OperationStatus;
+import software.amazon.cloudformation.proxy.ProgressEvent;
+import software.amazon.cloudformation.proxy.ProxyClient;
+import software.amazon.cloudformation.proxy.ResourceHandlerRequest;
+
+import java.time.Duration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
+import static software.amazon.connect.hoursofoperation.HoursOfOperationTestDataProvider.HOURS_OF_OPERATION_ARN;
+import static software.amazon.connect.hoursofoperation.HoursOfOperationTestDataProvider.HOURS_OF_OPERATION_ID;
+import static software.amazon.connect.hoursofoperation.HoursOfOperationTestDataProvider.buildHoursOfOperationDesiredStateResourceModel;
+
+@ExtendWith(MockitoExtension.class)
+public class ListHandlerTest {
+
+    private ListHandler handler;
+    private AmazonWebServicesClientProxy proxy;
+    private ProxyClient<ConnectClient> proxyClient;
+    private LoggerProxy logger;
+
+    @Mock
+    private ConnectClient connectClient;
+
+    @BeforeEach
+    public void setup() {
+        final Credentials MOCK_CREDENTIALS = new Credentials("accessKey", "secretKey", "token");
+        logger = new LoggerProxy();
+        handler = new ListHandler();
+        proxy = new AmazonWebServicesClientProxy(logger, MOCK_CREDENTIALS, () -> Duration.ofSeconds(600).toMillis());
+        proxyClient = proxy.newProxy(() -> connectClient);
+    }
+
+    @AfterEach
+    public void post_execute() {
+        verifyNoMoreInteractions(proxyClient.client());
+    }
+
+    @Test
+    public void testHandleRequest_Success() {
+        final ArgumentCaptor<ListHoursOfOperationsRequest> listHoursOfOperationsRequestArgumentCaptor = ArgumentCaptor.forClass(ListHoursOfOperationsRequest.class);
+
+        final ListHoursOfOperationsResponse listHoursOfOperationsResponse = buildListHoursOfOperationResponse(null);
+
+        final ResourceHandlerRequest<ResourceModel> request = ResourceHandlerRequest.<ResourceModel>builder()
+                .desiredResourceState(buildHoursOfOperationDesiredStateResourceModel())
+                .build();
+
+        when(proxyClient.client().listHoursOfOperations(listHoursOfOperationsRequestArgumentCaptor.capture())).thenReturn(listHoursOfOperationsResponse);
+
+        final ProgressEvent<ResourceModel, CallbackContext> response =
+                handler.handleRequest(proxy, request, new CallbackContext(), proxyClient, logger);
+
+        assertThat(response).isNotNull();
+        assertThat(response.getStatus()).isEqualTo(OperationStatus.SUCCESS);
+        assertThat(response.getCallbackContext()).isNull();
+        assertThat(response.getCallbackDelaySeconds()).isEqualTo(0);
+        assertThat(response.getResourceModel()).isNull();
+        assertThat(response.getResourceModels()).isNotNull();
+        assertThat(response.getMessage()).isNull();
+        assertThat(response.getErrorCode()).isNull();
+        assertThat(response.getResourceModels().size()).isEqualTo(1);
+
+        verify(proxyClient.client()).listHoursOfOperations(listHoursOfOperationsRequestArgumentCaptor.capture());
+    }
+
+    @Test
+    public void testHandleRequest_Exception() {
+        final ArgumentCaptor<ListHoursOfOperationsRequest> listHoursOfOperationsRequestArgumentCaptor = ArgumentCaptor.forClass(ListHoursOfOperationsRequest.class);
+        final ResourceHandlerRequest<ResourceModel> request = ResourceHandlerRequest.<ResourceModel>builder()
+                .desiredResourceState(buildHoursOfOperationDesiredStateResourceModel())
+                .build();
+
+        when(proxyClient.client().listHoursOfOperations(listHoursOfOperationsRequestArgumentCaptor.capture())).thenThrow(new RuntimeException());
+
+        assertThrows(CfnGeneralServiceException.class, () ->
+                handler.handleRequest(proxy, request, new CallbackContext(), proxyClient, logger));
+
+        verify(proxyClient.client()).listHoursOfOperations(listHoursOfOperationsRequestArgumentCaptor.capture());
+    }
+
+    @Test
+    public void testHandleRequest_NullResourceModel() {
+        final ResourceHandlerRequest<ResourceModel> request = ResourceHandlerRequest.<ResourceModel>builder()
+                .build();
+        assertThrows(CfnInvalidRequestException.class, () ->
+                handler.handleRequest(proxy, request, new CallbackContext(), proxyClient, logger));
+        verify(connectClient, never()).serviceName();
+    }
+
+    @Test
+    public void testHandleRequest_NullInstanceArn() {
+        final ResourceModel model = ResourceModel.builder().build();
+        final ResourceHandlerRequest<ResourceModel> request = ResourceHandlerRequest.<ResourceModel>builder()
+                .desiredResourceState(model)
+                .build();
+        assertThrows(CfnInvalidRequestException.class, () ->
+                handler.handleRequest(proxy, request, new CallbackContext(), proxyClient, logger));
+        verify(connectClient, never()).serviceName();
+    }
+
+    protected static ListHoursOfOperationsResponse buildListHoursOfOperationResponse(String nextToken) {
+        HoursOfOperationSummary hoursOfOperationSummary = HoursOfOperationSummary.builder()
+                .arn(HOURS_OF_OPERATION_ARN)
+                .id(HOURS_OF_OPERATION_ID)
+                .build();
+        ListHoursOfOperationsResponse.Builder builder = ListHoursOfOperationsResponse.builder();
+        builder.hoursOfOperationSummaryList(hoursOfOperationSummary);
+        if (StringUtils.isNotBlank(nextToken)) {
+            builder.nextToken(nextToken);
+        }
+        return builder.build();
+    }
+}
+

--- a/aws-connect-hoursofoperation/src/test/java/software/amazon/connect/hoursofoperation/UpdateHandlerTest.java
+++ b/aws-connect-hoursofoperation/src/test/java/software/amazon/connect/hoursofoperation/UpdateHandlerTest.java
@@ -1,14 +1,25 @@
 package software.amazon.connect.hoursofoperation;
 
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Lists;
 import org.junit.jupiter.api.AfterEach;
 import org.mockito.ArgumentCaptor;
+import org.mockito.InOrder;
 import software.amazon.awssdk.services.connect.ConnectClient;
+import software.amazon.awssdk.services.connect.model.CreateHoursOfOperationOverrideRequest;
+import software.amazon.awssdk.services.connect.model.CreateHoursOfOperationOverrideResponse;
+import software.amazon.awssdk.services.connect.model.DeleteHoursOfOperationOverrideRequest;
+import software.amazon.awssdk.services.connect.model.DeleteHoursOfOperationOverrideResponse;
+import software.amazon.awssdk.services.connect.model.ListHoursOfOperationOverridesRequest;
+import software.amazon.awssdk.services.connect.model.ListHoursOfOperationOverridesResponse;
+import software.amazon.awssdk.services.connect.model.OverrideDays;
 import software.amazon.awssdk.services.connect.model.TagResourceRequest;
 import software.amazon.awssdk.services.connect.model.TagResourceResponse;
 import software.amazon.awssdk.services.connect.model.UntagResourceRequest;
 import software.amazon.awssdk.services.connect.model.UntagResourceResponse;
+import software.amazon.awssdk.services.connect.model.UpdateHoursOfOperationOverrideRequest;
+import software.amazon.awssdk.services.connect.model.UpdateHoursOfOperationOverrideResponse;
 import software.amazon.awssdk.services.connect.model.UpdateHoursOfOperationRequest;
 import software.amazon.awssdk.services.connect.model.UpdateHoursOfOperationResponse;
 import software.amazon.cloudformation.exceptions.CfnGeneralServiceException;
@@ -27,17 +38,24 @@ import software.amazon.cloudformation.proxy.ProxyClient;
 import software.amazon.cloudformation.proxy.ResourceHandlerRequest;
 
 import java.time.Duration;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.atMostOnce;
+import static org.mockito.Mockito.inOrder;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
+import static software.amazon.connect.hoursofoperation.HoursOfOperationTestDataProvider.DAY_ONE;
 import static software.amazon.connect.hoursofoperation.HoursOfOperationTestDataProvider.HOURS_OF_OPERATION_ARN;
 import static software.amazon.connect.hoursofoperation.HoursOfOperationTestDataProvider.HOURS_OF_OPERATION_CONFIG_ONE;
 import static software.amazon.connect.hoursofoperation.HoursOfOperationTestDataProvider.HOURS_OF_OPERATION_CONFIG_TWO;
@@ -45,18 +63,41 @@ import static software.amazon.connect.hoursofoperation.HoursOfOperationTestDataP
 import static software.amazon.connect.hoursofoperation.HoursOfOperationTestDataProvider.HOURS_OF_OPERATION_DESCRIPTION_TWO;
 import static software.amazon.connect.hoursofoperation.HoursOfOperationTestDataProvider.HOURS_OF_OPERATION_NAME_ONE;
 import static software.amazon.connect.hoursofoperation.HoursOfOperationTestDataProvider.HOURS_OF_OPERATION_NAME_TWO;
+import static software.amazon.connect.hoursofoperation.HoursOfOperationTestDataProvider.HOURS_OF_OPERATION_OVERRIDE_CONFIG_ONE;
+import static software.amazon.connect.hoursofoperation.HoursOfOperationTestDataProvider.HOURS_OF_OPERATION_OVERRIDE_DESCRIPTION;
+import static software.amazon.connect.hoursofoperation.HoursOfOperationTestDataProvider.HOURS_OF_OPERATION_OVERRIDE_ID_THREE;
 import static software.amazon.connect.hoursofoperation.HoursOfOperationTestDataProvider.INSTANCE_ARN;
 import static software.amazon.connect.hoursofoperation.HoursOfOperationTestDataProvider.INSTANCE_ARN_TWO;
+import static software.amazon.connect.hoursofoperation.HoursOfOperationTestDataProvider.NEXT_TOKEN;
+import static software.amazon.connect.hoursofoperation.HoursOfOperationTestDataProvider.OVERRIDE_EFFECTIVE_FROM;
+import static software.amazon.connect.hoursofoperation.HoursOfOperationTestDataProvider.OVERRIDE_EFFECTIVE_TILL;
+import static software.amazon.connect.hoursofoperation.HoursOfOperationTestDataProvider.OVERRIDE_NAME_ONE;
+import static software.amazon.connect.hoursofoperation.HoursOfOperationTestDataProvider.OVERRIDE_NAME_THREE;
+import static software.amazon.connect.hoursofoperation.HoursOfOperationTestDataProvider.OVERRIDE_TIMESLICE_HOUR_13;
+import static software.amazon.connect.hoursofoperation.HoursOfOperationTestDataProvider.OVERRIDE_TIMESLICE_HOUR_17;
+import static software.amazon.connect.hoursofoperation.HoursOfOperationTestDataProvider.OVERRIDE_TIMESLICE_HOUR_9;
+import static software.amazon.connect.hoursofoperation.HoursOfOperationTestDataProvider.OVERRIDE_TIMESLICE_MIN_0;
 import static software.amazon.connect.hoursofoperation.HoursOfOperationTestDataProvider.TAGS_ONE;
 import static software.amazon.connect.hoursofoperation.HoursOfOperationTestDataProvider.TAGS_SET_ONE;
 import static software.amazon.connect.hoursofoperation.HoursOfOperationTestDataProvider.TAGS_THREE;
 import static software.amazon.connect.hoursofoperation.HoursOfOperationTestDataProvider.TAGS_TWO;
+import static software.amazon.connect.hoursofoperation.HoursOfOperationTestDataProvider.TUESDAY;
 import static software.amazon.connect.hoursofoperation.HoursOfOperationTestDataProvider.VALID_TAG_KEY_THREE;
 import static software.amazon.connect.hoursofoperation.HoursOfOperationTestDataProvider.VALID_TAG_KEY_TWO;
 import static software.amazon.connect.hoursofoperation.HoursOfOperationTestDataProvider.VALID_TAG_VALUE_THREE;
+import static software.amazon.connect.hoursofoperation.HoursOfOperationTestDataProvider.buildHOOPEmptyOverrideDesiredStateResourceModel;
+import static software.amazon.connect.hoursofoperation.HoursOfOperationTestDataProvider.buildHOOPOverrideDesiredStateResourceModel;
+import static software.amazon.connect.hoursofoperation.HoursOfOperationTestDataProvider.buildHOOPOverrideDesiredStateResourceModelThree;
+import static software.amazon.connect.hoursofoperation.HoursOfOperationTestDataProvider.buildHOOPOverridePreviousStateResourceModel;
+import static software.amazon.connect.hoursofoperation.HoursOfOperationTestDataProvider.buildHOOPOverridesPreviousStateResourceModel;
 import static software.amazon.connect.hoursofoperation.HoursOfOperationTestDataProvider.buildHoursOfOperationDesiredStateResourceModel;
 import static software.amazon.connect.hoursofoperation.HoursOfOperationTestDataProvider.buildHoursOfOperationPreviousStateResourceModel;
 import static software.amazon.connect.hoursofoperation.HoursOfOperationTestDataProvider.getConfig;
+import static software.amazon.connect.hoursofoperation.HoursOfOperationTestDataProvider.getHoursOfOperationOverrideOne;
+import static software.amazon.connect.hoursofoperation.HoursOfOperationTestDataProvider.getHoursOfOperationOverrideThree;
+import static software.amazon.connect.hoursofoperation.HoursOfOperationTestDataProvider.getHoursOfOperationOverrideTwo;
+import static software.amazon.connect.hoursofoperation.HoursOfOperationTestDataProvider.getListHOOPOverridesResponse;
+import static software.amazon.connect.hoursofoperation.HoursOfOperationTestDataProvider.getOverride;
 import static software.amazon.connect.hoursofoperation.HoursOfOperationTestDataProvider.validateConfig;
 
 @ExtendWith(MockitoExtension.class)
@@ -85,7 +126,7 @@ public class UpdateHandlerTest {
     }
 
     @Test
-    public void testHandleRequest_Success() {
+    public void testHandleRequestWithoutOverrides_Success() {
         final ArgumentCaptor<UpdateHoursOfOperationRequest> updateHoursOfOperationRequestArgumentCaptor = ArgumentCaptor.forClass(UpdateHoursOfOperationRequest.class);
         final ArgumentCaptor<TagResourceRequest> tagResourceRequestArgumentCaptor = ArgumentCaptor.forClass(TagResourceRequest.class);
         final ArgumentCaptor<UntagResourceRequest> untagResourceRequestArgumentCaptor = ArgumentCaptor.forClass(UntagResourceRequest.class);
@@ -108,15 +149,7 @@ public class UpdateHandlerTest {
                 .build();
 
         final ProgressEvent<ResourceModel, CallbackContext> response = handler.handleRequest(proxy, request, new CallbackContext(), proxyClient, logger);
-
-        assertThat(response).isNotNull();
-        assertThat(response.getStatus()).isEqualTo(OperationStatus.SUCCESS);
-        assertThat(response.getCallbackContext()).isNull();
-        assertThat(response.getCallbackDelaySeconds()).isEqualTo(0);
-        assertThat(response.getResourceModel()).isEqualTo(request.getDesiredResourceState());
-        assertThat(response.getResourceModels()).isNull();
-        assertThat(response.getMessage()).isNull();
-        assertThat(response.getErrorCode()).isNull();
+        validateResponse(request, response);
 
         verify(proxyClient.client()).updateHoursOfOperation(updateHoursOfOperationRequestArgumentCaptor.capture());
         assertThat(updateHoursOfOperationRequestArgumentCaptor.getValue().instanceId()).isEqualTo(INSTANCE_ARN);
@@ -149,8 +182,8 @@ public class UpdateHandlerTest {
                 .build();
 
         final ArgumentCaptor<UpdateHoursOfOperationRequest> updateHoursOfOperationRequestArgumentCaptor = ArgumentCaptor.forClass(UpdateHoursOfOperationRequest.class);
-
         final UpdateHoursOfOperationResponse updateHoursOfOperationResponse = UpdateHoursOfOperationResponse.builder().build();
+
         when(proxyClient.client().updateHoursOfOperation(updateHoursOfOperationRequestArgumentCaptor.capture())).thenReturn(updateHoursOfOperationResponse);
 
         final ResourceHandlerRequest<ResourceModel> request = ResourceHandlerRequest.<ResourceModel>builder()
@@ -161,15 +194,7 @@ public class UpdateHandlerTest {
                 .build();
 
         final ProgressEvent<ResourceModel, CallbackContext> response = handler.handleRequest(proxy, request, new CallbackContext(), proxyClient, logger);
-
-        assertThat(response).isNotNull();
-        assertThat(response.getStatus()).isEqualTo(OperationStatus.SUCCESS);
-        assertThat(response.getCallbackContext()).isNull();
-        assertThat(response.getCallbackDelaySeconds()).isEqualTo(0);
-        assertThat(response.getResourceModel()).isEqualTo(request.getDesiredResourceState());
-        assertThat(response.getResourceModels()).isNull();
-        assertThat(response.getMessage()).isNull();
-        assertThat(response.getErrorCode()).isNull();
+        validateResponse(request, response);
 
         verify(proxyClient.client()).updateHoursOfOperation(updateHoursOfOperationRequestArgumentCaptor.capture());
         assertThat(updateHoursOfOperationRequestArgumentCaptor.getValue().instanceId()).isEqualTo(INSTANCE_ARN);
@@ -178,7 +203,7 @@ public class UpdateHandlerTest {
         assertThat(updateHoursOfOperationRequestArgumentCaptor.getValue().description()).isEqualTo("");
         assertThat(updateHoursOfOperationRequestArgumentCaptor.getValue().config()).isNotNull();
         validateConfig(updateHoursOfOperationRequestArgumentCaptor.getValue().config());
-
+        
         verify(connectClient, atMostOnce()).serviceName();
     }
 
@@ -300,5 +325,578 @@ public class UpdateHandlerTest {
         assertThat(untagResourceRequestArgumentCaptor.getValue().tagKeys()).hasSameElementsAs(unTagKeys);
 
         verify(connectClient, times(2)).serviceName();
+    }
+
+    @Test
+    public void testHandleRequestWithNewOverrides_Success() {
+        final ArgumentCaptor<UpdateHoursOfOperationRequest> updateHoursOfOperationRequestArgumentCaptor = ArgumentCaptor.forClass(UpdateHoursOfOperationRequest.class);
+        final ArgumentCaptor<ListHoursOfOperationOverridesRequest> listHoursOfOperationOverridesRequestArgumentCaptor = ArgumentCaptor.forClass(ListHoursOfOperationOverridesRequest.class);
+        final ArgumentCaptor<CreateHoursOfOperationOverrideRequest> createHoursOfOperationOverrideRequestArgumentCaptor = ArgumentCaptor.forClass(CreateHoursOfOperationOverrideRequest.class);
+        final ArgumentCaptor<DeleteHoursOfOperationOverrideRequest> deleteHoursOfOperationOverrideRequestArgumentCaptor = ArgumentCaptor.forClass(DeleteHoursOfOperationOverrideRequest.class);
+
+        final UpdateHoursOfOperationResponse updateHoursOfOperationResponse = UpdateHoursOfOperationResponse.builder().build();
+        final ListHoursOfOperationOverridesResponse listHoursOfOperationOverridesResponse = ListHoursOfOperationOverridesResponse.builder()
+                .hoursOfOperationOverrideList(ImmutableList.of(getHoursOfOperationOverrideTwo()))
+                .nextToken(null)
+                .build();
+
+        final CreateHoursOfOperationOverrideResponse createHoursOfOperationOverrideResponse = CreateHoursOfOperationOverrideResponse.builder().build();
+        final DeleteHoursOfOperationOverrideResponse deleteHoursOfOperationOverrideResponse = DeleteHoursOfOperationOverrideResponse.builder().build();
+
+        when(proxyClient.client().updateHoursOfOperation(updateHoursOfOperationRequestArgumentCaptor.capture())).thenReturn(updateHoursOfOperationResponse);
+        when(proxyClient.client().listHoursOfOperationOverrides(listHoursOfOperationOverridesRequestArgumentCaptor.capture())).thenReturn(listHoursOfOperationOverridesResponse);
+        when(proxyClient.client().createHoursOfOperationOverride(createHoursOfOperationOverrideRequestArgumentCaptor.capture())).thenReturn(createHoursOfOperationOverrideResponse);
+        when(proxyClient.client().deleteHoursOfOperationOverride(deleteHoursOfOperationOverrideRequestArgumentCaptor.capture())).thenReturn(deleteHoursOfOperationOverrideResponse);
+
+        final ResourceHandlerRequest<ResourceModel> request = ResourceHandlerRequest.<ResourceModel>builder()
+                .desiredResourceState(buildHOOPOverrideDesiredStateResourceModel())
+                .previousResourceState(buildHOOPOverridePreviousStateResourceModel())
+                .build();
+
+        final ProgressEvent<ResourceModel, CallbackContext> response = handler.handleRequest(proxy, request, new CallbackContext(), proxyClient, logger);
+        validateResponse(request, response);
+
+        verify(proxyClient.client()).updateHoursOfOperation(updateHoursOfOperationRequestArgumentCaptor.capture());
+        assertThat(updateHoursOfOperationRequestArgumentCaptor.getValue().instanceId()).isEqualTo(INSTANCE_ARN);
+        assertThat(updateHoursOfOperationRequestArgumentCaptor.getValue().hoursOfOperationId()).isEqualTo(HOURS_OF_OPERATION_ARN);
+        assertThat(updateHoursOfOperationRequestArgumentCaptor.getValue().name()).isEqualTo(HOURS_OF_OPERATION_NAME_ONE);
+        assertThat(updateHoursOfOperationRequestArgumentCaptor.getValue().description()).isEqualTo(HOURS_OF_OPERATION_DESCRIPTION_ONE);
+        assertThat(updateHoursOfOperationRequestArgumentCaptor.getValue().config()).isNotNull();
+        validateConfig(updateHoursOfOperationRequestArgumentCaptor.getValue().config());
+
+        // override related fields
+        verify(proxyClient.client()).createHoursOfOperationOverride(createHoursOfOperationOverrideRequestArgumentCaptor.capture());
+        CreateHoursOfOperationOverrideRequest createOverrideRequest = createHoursOfOperationOverrideRequestArgumentCaptor.getValue();
+        validateRequest(createOverrideRequest, TUESDAY, OVERRIDE_TIMESLICE_HOUR_9, OVERRIDE_TIMESLICE_HOUR_17, OVERRIDE_NAME_ONE, HOURS_OF_OPERATION_OVERRIDE_DESCRIPTION);
+
+        verify(proxyClient.client()).deleteHoursOfOperationOverride(deleteHoursOfOperationOverrideRequestArgumentCaptor.capture());
+        DeleteHoursOfOperationOverrideRequest overrideDeleteRequest = deleteHoursOfOperationOverrideRequestArgumentCaptor.getValue();
+        assertEquals(INSTANCE_ARN, overrideDeleteRequest.instanceId());
+        assertEquals(HOURS_OF_OPERATION_ARN, overrideDeleteRequest.hoursOfOperationId());
+        verify(connectClient, times(3)).serviceName();
+    }
+
+    @Test
+    public void testHandleRequestWithExistingOverrides_Success() {
+        final ArgumentCaptor<UpdateHoursOfOperationRequest> updateHoursOfOperationRequestArgumentCaptor = ArgumentCaptor.forClass(UpdateHoursOfOperationRequest.class);
+        final ArgumentCaptor<ListHoursOfOperationOverridesRequest> listHoursOfOperationOverridesRequestArgumentCaptor = ArgumentCaptor.forClass(ListHoursOfOperationOverridesRequest.class);
+        final ArgumentCaptor<CreateHoursOfOperationOverrideRequest> createHoursOfOperationOverrideRequestArgumentCaptor = ArgumentCaptor.forClass(CreateHoursOfOperationOverrideRequest.class);
+        final ArgumentCaptor<DeleteHoursOfOperationOverrideRequest> deleteHoursOfOperationOverrideRequestArgumentCaptor = ArgumentCaptor.forClass(DeleteHoursOfOperationOverrideRequest.class);
+
+        final UpdateHoursOfOperationResponse updateHoursOfOperationResponse = UpdateHoursOfOperationResponse.builder().build();
+        final ListHoursOfOperationOverridesResponse listHoursOfOperationOverridesResponsePageOne = getListHOOPOverridesResponse(NEXT_TOKEN, getHoursOfOperationOverrideOne());
+        final ListHoursOfOperationOverridesResponse listHoursOfOperationOverridesResponsePageTwo = getListHOOPOverridesResponse(null, getHoursOfOperationOverrideTwo());
+        final CreateHoursOfOperationOverrideResponse createHoursOfOperationOverrideResponse = CreateHoursOfOperationOverrideResponse.builder().build();
+        final DeleteHoursOfOperationOverrideResponse deleteHoursOfOperationOverrideResponse = DeleteHoursOfOperationOverrideResponse.builder().build();
+
+        when(proxyClient.client().updateHoursOfOperation(updateHoursOfOperationRequestArgumentCaptor.capture())).thenReturn(updateHoursOfOperationResponse);
+        when(proxyClient.client().listHoursOfOperationOverrides(listHoursOfOperationOverridesRequestArgumentCaptor.capture())).thenReturn(listHoursOfOperationOverridesResponsePageOne)
+                .thenReturn(listHoursOfOperationOverridesResponsePageTwo);
+        when(proxyClient.client().createHoursOfOperationOverride(createHoursOfOperationOverrideRequestArgumentCaptor.capture())).thenReturn(createHoursOfOperationOverrideResponse);
+        when(proxyClient.client().deleteHoursOfOperationOverride(deleteHoursOfOperationOverrideRequestArgumentCaptor.capture())).thenReturn(deleteHoursOfOperationOverrideResponse);
+
+        final ResourceHandlerRequest<ResourceModel> request = ResourceHandlerRequest.<ResourceModel>builder()
+                .desiredResourceState(buildHOOPOverrideDesiredStateResourceModelThree())
+                .previousResourceState(buildHOOPOverridesPreviousStateResourceModel())
+                .build();
+
+        final ProgressEvent<ResourceModel, CallbackContext> response = handler.handleRequest(proxy, request, new CallbackContext(), proxyClient, logger);
+        validateResponse(request, response);
+
+        InOrder inorder = inOrder(proxyClient.client());
+
+        inorder.verify(proxyClient.client()).updateHoursOfOperation(updateHoursOfOperationRequestArgumentCaptor.capture());
+        assertThat(updateHoursOfOperationRequestArgumentCaptor.getValue().instanceId()).isEqualTo(INSTANCE_ARN);
+        assertThat(updateHoursOfOperationRequestArgumentCaptor.getValue().hoursOfOperationId()).isEqualTo(HOURS_OF_OPERATION_ARN);
+        assertThat(updateHoursOfOperationRequestArgumentCaptor.getValue().name()).isEqualTo(HOURS_OF_OPERATION_NAME_ONE);
+        assertThat(updateHoursOfOperationRequestArgumentCaptor.getValue().description()).isEqualTo(HOURS_OF_OPERATION_DESCRIPTION_ONE);
+        assertThat(updateHoursOfOperationRequestArgumentCaptor.getValue().config()).isNotNull();
+        validateConfig(updateHoursOfOperationRequestArgumentCaptor.getValue().config());
+
+        // override list call
+        inorder.verify(proxyClient.client(), times(2)).listHoursOfOperationOverrides(listHoursOfOperationOverridesRequestArgumentCaptor.capture());
+        List<ListHoursOfOperationOverridesRequest> listOverrideRequest = listHoursOfOperationOverridesRequestArgumentCaptor.getAllValues();
+        assertEquals(INSTANCE_ARN, listOverrideRequest.get(0).instanceId());
+        assertEquals(HOURS_OF_OPERATION_ARN, listOverrideRequest.get(0).hoursOfOperationId());
+        assertNull(listOverrideRequest.get(0).nextToken());
+        assertEquals(INSTANCE_ARN, listOverrideRequest.get(1).instanceId());
+        assertEquals(HOURS_OF_OPERATION_ARN, listOverrideRequest.get(1).hoursOfOperationId());
+        assertEquals(NEXT_TOKEN, listOverrideRequest.get(1).nextToken());
+
+        inorder.verify(proxyClient.client(), times(2)).deleteHoursOfOperationOverride(deleteHoursOfOperationOverrideRequestArgumentCaptor.capture());
+        DeleteHoursOfOperationOverrideRequest overrideDeleteRequest = deleteHoursOfOperationOverrideRequestArgumentCaptor.getValue();
+        assertEquals(INSTANCE_ARN, overrideDeleteRequest.instanceId());
+        assertEquals(HOURS_OF_OPERATION_ARN, overrideDeleteRequest.hoursOfOperationId());
+
+        inorder.verify(proxyClient.client()).createHoursOfOperationOverride(createHoursOfOperationOverrideRequestArgumentCaptor.capture());
+        CreateHoursOfOperationOverrideRequest createOverrideRequest = createHoursOfOperationOverrideRequestArgumentCaptor.getValue();
+        validateRequest(createOverrideRequest, DAY_ONE, OVERRIDE_TIMESLICE_HOUR_9, OVERRIDE_TIMESLICE_HOUR_13, OVERRIDE_NAME_THREE, HOURS_OF_OPERATION_OVERRIDE_DESCRIPTION);
+
+        verify(connectClient, times(4)).serviceName();
+    }
+
+    @Test
+    public void testHandleRequestWithAnOldOverrideUpdatedById() {
+        final ArgumentCaptor<UpdateHoursOfOperationRequest> updateHoursOfOperationRequestArgumentCaptor = ArgumentCaptor.forClass(UpdateHoursOfOperationRequest.class);
+        final ArgumentCaptor<ListHoursOfOperationOverridesRequest> listHoursOfOperationOverridesRequestArgumentCaptor = ArgumentCaptor.forClass(ListHoursOfOperationOverridesRequest.class);
+        final ArgumentCaptor<UpdateHoursOfOperationOverrideRequest> updateHoursOfOperationOverrideRequestArgumentCaptor = ArgumentCaptor.forClass(UpdateHoursOfOperationOverrideRequest.class);
+
+        final UpdateHoursOfOperationResponse updateHoursOfOperationResponse = UpdateHoursOfOperationResponse.builder().build();
+        final ListHoursOfOperationOverridesResponse listHoursOfOperationOverridesResponse = ListHoursOfOperationOverridesResponse.builder()
+                .hoursOfOperationOverrideList(ImmutableList.of(getHoursOfOperationOverrideThree()))
+                .nextToken(null)
+                .build();
+        final UpdateHoursOfOperationOverrideResponse updateHoursOfOperationOverrideResponse = UpdateHoursOfOperationOverrideResponse.builder().build();
+
+        when(proxyClient.client().updateHoursOfOperation(updateHoursOfOperationRequestArgumentCaptor.capture())).thenReturn(updateHoursOfOperationResponse);
+        when(proxyClient.client().listHoursOfOperationOverrides(listHoursOfOperationOverridesRequestArgumentCaptor.capture())).thenReturn(listHoursOfOperationOverridesResponse);
+        when(proxyClient.client().updateHoursOfOperationOverride(updateHoursOfOperationOverrideRequestArgumentCaptor.capture())).thenReturn(updateHoursOfOperationOverrideResponse);
+
+        // we update the description of override-one as part of the desired state
+        ResourceModel previousModel = buildHOOPOverrideDesiredStateResourceModelThree();
+        previousModel.getHoursOfOperationOverrides().get(0).setHoursOfOperationOverrideId(null); // Override id is not persisted in previous state
+        ResourceModel desiredModel = buildHOOPOverrideDesiredStateResourceModelThree();
+        desiredModel.getHoursOfOperationOverrides().get(0).setOverrideDescription("Override description updated");
+
+        final ResourceHandlerRequest<ResourceModel> request = ResourceHandlerRequest.<ResourceModel>builder()
+                .desiredResourceState(desiredModel)
+                .previousResourceState(previousModel)
+                .build();
+
+        final ProgressEvent<ResourceModel, CallbackContext> response = handler.handleRequest(proxy, request, new CallbackContext(), proxyClient, logger);
+        validateResponse(request, response);
+
+        // HOOP should be updated
+        verify(proxyClient.client(), times(1)).updateHoursOfOperation(updateHoursOfOperationRequestArgumentCaptor.capture());
+        assertThat(updateHoursOfOperationRequestArgumentCaptor.getValue().instanceId()).isEqualTo(INSTANCE_ARN);
+        assertThat(updateHoursOfOperationRequestArgumentCaptor.getValue().hoursOfOperationId()).isEqualTo(HOURS_OF_OPERATION_ARN);
+        assertThat(updateHoursOfOperationRequestArgumentCaptor.getValue().name()).isEqualTo(HOURS_OF_OPERATION_NAME_ONE);
+        assertThat(updateHoursOfOperationRequestArgumentCaptor.getValue().description()).isEqualTo(HOURS_OF_OPERATION_DESCRIPTION_ONE);
+        assertThat(updateHoursOfOperationRequestArgumentCaptor.getValue().config()).isNotNull();
+        validateConfig(updateHoursOfOperationRequestArgumentCaptor.getValue().config());
+
+        // override list call
+        verify(proxyClient.client(), times(1)).listHoursOfOperationOverrides(listHoursOfOperationOverridesRequestArgumentCaptor.capture());
+        List<ListHoursOfOperationOverridesRequest> listOverrideRequest = listHoursOfOperationOverridesRequestArgumentCaptor.getAllValues();
+        assertEquals(INSTANCE_ARN, listOverrideRequest.get(0).instanceId());
+        assertEquals(HOURS_OF_OPERATION_ARN, listOverrideRequest.get(0).hoursOfOperationId());
+
+        // Create and Delete override apis should not be called.
+        verify(proxyClient.client(), never()).createHoursOfOperationOverride(any(CreateHoursOfOperationOverrideRequest.class));
+        verify(proxyClient.client(), never()).deleteHoursOfOperationOverride(any(DeleteHoursOfOperationOverrideRequest.class));
+
+        // override related fields
+        verify(proxyClient.client(), times(1)).updateHoursOfOperationOverride(updateHoursOfOperationOverrideRequestArgumentCaptor.capture());
+        UpdateHoursOfOperationOverrideRequest updateOverrideRequest = updateHoursOfOperationOverrideRequestArgumentCaptor.getValue();
+        validateUpdateOverrideRequest(updateOverrideRequest, HOURS_OF_OPERATION_OVERRIDE_ID_THREE, DAY_ONE, OVERRIDE_TIMESLICE_HOUR_9, OVERRIDE_TIMESLICE_HOUR_13, OVERRIDE_NAME_THREE, "Override description updated");
+        verify(connectClient, times(2)).serviceName();
+    }
+
+    @Test
+    public void testHandleRequestWithAnOldOverrideUpdatedByName() {
+        final ArgumentCaptor<UpdateHoursOfOperationRequest> updateHoursOfOperationRequestArgumentCaptor = ArgumentCaptor.forClass(UpdateHoursOfOperationRequest.class);
+        final ArgumentCaptor<ListHoursOfOperationOverridesRequest> listHoursOfOperationOverridesRequestArgumentCaptor = ArgumentCaptor.forClass(ListHoursOfOperationOverridesRequest.class);
+        final ArgumentCaptor<UpdateHoursOfOperationOverrideRequest> updateHoursOfOperationOverrideRequestArgumentCaptor = ArgumentCaptor.forClass(UpdateHoursOfOperationOverrideRequest.class);
+
+        final UpdateHoursOfOperationResponse updateHoursOfOperationResponse = UpdateHoursOfOperationResponse.builder().build();
+        final ListHoursOfOperationOverridesResponse listHoursOfOperationOverridesResponse = ListHoursOfOperationOverridesResponse.builder()
+                .hoursOfOperationOverrideList(ImmutableList.of(getHoursOfOperationOverrideThree()))
+                .nextToken(null)
+                .build();
+        final UpdateHoursOfOperationOverrideResponse updateHoursOfOperationOverrideResponse = UpdateHoursOfOperationOverrideResponse.builder().build();
+
+        when(proxyClient.client().updateHoursOfOperation(updateHoursOfOperationRequestArgumentCaptor.capture())).thenReturn(updateHoursOfOperationResponse);
+        when(proxyClient.client().listHoursOfOperationOverrides(listHoursOfOperationOverridesRequestArgumentCaptor.capture())).thenReturn(listHoursOfOperationOverridesResponse);
+        when(proxyClient.client().updateHoursOfOperationOverride(updateHoursOfOperationOverrideRequestArgumentCaptor.capture())).thenReturn(updateHoursOfOperationOverrideResponse);
+
+        // we update the description of override-one as part of the desired state
+        ResourceModel previousModel = buildHOOPOverrideDesiredStateResourceModelThree();
+        previousModel.getHoursOfOperationOverrides().get(0).setHoursOfOperationOverrideId(null);
+        ResourceModel desiredModel = buildHOOPOverrideDesiredStateResourceModelThree();
+        desiredModel.getHoursOfOperationOverrides().get(0).setOverrideDescription("Override description updated");
+        desiredModel.getHoursOfOperationOverrides().get(0).setHoursOfOperationOverrideId(null);
+
+        final ResourceHandlerRequest<ResourceModel> request = ResourceHandlerRequest.<ResourceModel>builder()
+                .desiredResourceState(desiredModel)
+                .previousResourceState(previousModel)
+                .build();
+
+        final ProgressEvent<ResourceModel, CallbackContext> response = handler.handleRequest(proxy, request, new CallbackContext(), proxyClient, logger);
+        validateResponse(request, response);
+
+        // HOOP should be updated
+        verify(proxyClient.client(), times(1)).updateHoursOfOperation(updateHoursOfOperationRequestArgumentCaptor.capture());
+        assertThat(updateHoursOfOperationRequestArgumentCaptor.getValue().instanceId()).isEqualTo(INSTANCE_ARN);
+        assertThat(updateHoursOfOperationRequestArgumentCaptor.getValue().hoursOfOperationId()).isEqualTo(HOURS_OF_OPERATION_ARN);
+        assertThat(updateHoursOfOperationRequestArgumentCaptor.getValue().name()).isEqualTo(HOURS_OF_OPERATION_NAME_ONE);
+        assertThat(updateHoursOfOperationRequestArgumentCaptor.getValue().description()).isEqualTo(HOURS_OF_OPERATION_DESCRIPTION_ONE);
+        assertThat(updateHoursOfOperationRequestArgumentCaptor.getValue().config()).isNotNull();
+        validateConfig(updateHoursOfOperationRequestArgumentCaptor.getValue().config());
+
+        // override list call
+        verify(proxyClient.client(), times(1)).listHoursOfOperationOverrides(listHoursOfOperationOverridesRequestArgumentCaptor.capture());
+        List<ListHoursOfOperationOverridesRequest> listOverrideRequest = listHoursOfOperationOverridesRequestArgumentCaptor.getAllValues();
+        assertEquals(INSTANCE_ARN, listOverrideRequest.get(0).instanceId());
+        assertEquals(HOURS_OF_OPERATION_ARN, listOverrideRequest.get(0).hoursOfOperationId());
+
+        // Create and Delete override apis should not be called.
+        verify(proxyClient.client(), never()).createHoursOfOperationOverride(any(CreateHoursOfOperationOverrideRequest.class));
+        verify(proxyClient.client(), never()).deleteHoursOfOperationOverride(any(DeleteHoursOfOperationOverrideRequest.class));
+
+        // override related fields
+        verify(proxyClient.client(), times(1)).updateHoursOfOperationOverride(updateHoursOfOperationOverrideRequestArgumentCaptor.capture());
+        UpdateHoursOfOperationOverrideRequest updateOverrideRequest = updateHoursOfOperationOverrideRequestArgumentCaptor.getValue();
+        validateUpdateOverrideRequest(updateOverrideRequest, HOURS_OF_OPERATION_OVERRIDE_ID_THREE, DAY_ONE, OVERRIDE_TIMESLICE_HOUR_9, OVERRIDE_TIMESLICE_HOUR_13, OVERRIDE_NAME_THREE, "Override description updated");
+        verify(connectClient, times(2)).serviceName();
+    }
+
+    @Test
+    public void testUpdateOverrideWithDifferentOverrideId() {
+        final ArgumentCaptor<UpdateHoursOfOperationRequest> updateHoursOfOperationRequestArgumentCaptor = ArgumentCaptor.forClass(UpdateHoursOfOperationRequest.class);
+        final ArgumentCaptor<CreateHoursOfOperationOverrideRequest> createHoursOfOperationOverrideRequestArgumentCaptor = ArgumentCaptor.forClass(CreateHoursOfOperationOverrideRequest.class);
+        final ArgumentCaptor<ListHoursOfOperationOverridesRequest> listHoursOfOperationOverridesRequestArgumentCaptor = ArgumentCaptor.forClass(ListHoursOfOperationOverridesRequest.class);
+        final ArgumentCaptor<DeleteHoursOfOperationOverrideRequest> deleteHoursOfOperationOverrideRequestArgumentCaptor = ArgumentCaptor.forClass(DeleteHoursOfOperationOverrideRequest.class);
+
+        final UpdateHoursOfOperationResponse updateHoursOfOperationResponse = UpdateHoursOfOperationResponse.builder().build();
+        final ListHoursOfOperationOverridesResponse listHoursOfOperationOverridesResponse = ListHoursOfOperationOverridesResponse.builder()
+                .hoursOfOperationOverrideList(ImmutableList.of(getHoursOfOperationOverrideThree()))
+                .nextToken(null)
+                .build();
+        final CreateHoursOfOperationOverrideResponse createHoursOfOperationOverrideResponse = CreateHoursOfOperationOverrideResponse.builder().build();
+        final DeleteHoursOfOperationOverrideResponse deleteHoursOfOperationOverrideResponse = DeleteHoursOfOperationOverrideResponse.builder().build();
+
+        when(proxyClient.client().updateHoursOfOperation(updateHoursOfOperationRequestArgumentCaptor.capture())).thenReturn(updateHoursOfOperationResponse);
+        when(proxyClient.client().listHoursOfOperationOverrides(listHoursOfOperationOverridesRequestArgumentCaptor.capture())).thenReturn(listHoursOfOperationOverridesResponse);
+        when(proxyClient.client().createHoursOfOperationOverride(createHoursOfOperationOverrideRequestArgumentCaptor.capture())).thenReturn(createHoursOfOperationOverrideResponse);
+        when(proxyClient.client().deleteHoursOfOperationOverride(deleteHoursOfOperationOverrideRequestArgumentCaptor.capture())).thenReturn(deleteHoursOfOperationOverrideResponse);
+
+        // we update the description of override-one as part of the desired state
+        ResourceModel previousModel = buildHOOPOverrideDesiredStateResourceModelThree();
+        previousModel.getHoursOfOperationOverrides().get(0).setHoursOfOperationOverrideId(null);
+        ResourceModel desiredModel = buildHOOPOverrideDesiredStateResourceModelThree();
+        desiredModel.getHoursOfOperationOverrides().get(0).setOverrideDescription("Override description updated");
+        // provide a different override id for override-three
+        desiredModel.getHoursOfOperationOverrides().get(0).setHoursOfOperationOverrideId("override-four");
+
+        final ResourceHandlerRequest<ResourceModel> request = ResourceHandlerRequest.<ResourceModel>builder()
+                .desiredResourceState(desiredModel)
+                .previousResourceState(previousModel)
+                .build();
+
+        final ProgressEvent<ResourceModel, CallbackContext> response = handler.handleRequest(proxy, request, new CallbackContext(), proxyClient, logger);
+        validateResponse(request, response);
+
+        // HOOP should be updated
+        verify(proxyClient.client(), times(1)).updateHoursOfOperation(updateHoursOfOperationRequestArgumentCaptor.capture());
+        assertThat(updateHoursOfOperationRequestArgumentCaptor.getValue().instanceId()).isEqualTo(INSTANCE_ARN);
+        assertThat(updateHoursOfOperationRequestArgumentCaptor.getValue().hoursOfOperationId()).isEqualTo(HOURS_OF_OPERATION_ARN);
+        assertThat(updateHoursOfOperationRequestArgumentCaptor.getValue().name()).isEqualTo(HOURS_OF_OPERATION_NAME_ONE);
+        assertThat(updateHoursOfOperationRequestArgumentCaptor.getValue().description()).isEqualTo(HOURS_OF_OPERATION_DESCRIPTION_ONE);
+        assertThat(updateHoursOfOperationRequestArgumentCaptor.getValue().config()).isNotNull();
+        validateConfig(updateHoursOfOperationRequestArgumentCaptor.getValue().config());
+
+        // override list call
+        verify(proxyClient.client(), times(1)).listHoursOfOperationOverrides(listHoursOfOperationOverridesRequestArgumentCaptor.capture());
+        List<ListHoursOfOperationOverridesRequest> listOverrideRequest = listHoursOfOperationOverridesRequestArgumentCaptor.getAllValues();
+        assertEquals(INSTANCE_ARN, listOverrideRequest.get(0).instanceId());
+        assertEquals(HOURS_OF_OPERATION_ARN, listOverrideRequest.get(0).hoursOfOperationId());
+
+        // a new override will be created with id as 'override-four'
+        verify(proxyClient.client()).createHoursOfOperationOverride(createHoursOfOperationOverrideRequestArgumentCaptor.capture());
+        CreateHoursOfOperationOverrideRequest createOverrideRequest = createHoursOfOperationOverrideRequestArgumentCaptor.getValue();
+        validateRequest(createOverrideRequest, DAY_ONE, OVERRIDE_TIMESLICE_HOUR_9, OVERRIDE_TIMESLICE_HOUR_13, OVERRIDE_NAME_THREE, "Override description updated");
+
+        // override delete call
+        verify(proxyClient.client(), times(1)).deleteHoursOfOperationOverride(any(DeleteHoursOfOperationOverrideRequest.class));
+        DeleteHoursOfOperationOverrideRequest overrideDeleteRequest = deleteHoursOfOperationOverrideRequestArgumentCaptor.getValue();
+        assertEquals(INSTANCE_ARN, overrideDeleteRequest.instanceId());
+        assertEquals(HOURS_OF_OPERATION_ARN, overrideDeleteRequest.hoursOfOperationId());
+        assertEquals(HOURS_OF_OPERATION_OVERRIDE_ID_THREE, overrideDeleteRequest.hoursOfOperationOverrideId());
+
+        // Update api will not be invoked.
+        verify(proxyClient.client(), never()).updateHoursOfOperationOverride(any(UpdateHoursOfOperationOverrideRequest.class));
+
+        verify(connectClient, times(3)).serviceName();
+    }
+
+    @Test
+    public void testUpdateOverrideWithConfigUnchangedButWithDifferentId() {
+        final ArgumentCaptor<UpdateHoursOfOperationRequest> updateHoursOfOperationRequestArgumentCaptor = ArgumentCaptor.forClass(UpdateHoursOfOperationRequest.class);
+        final ArgumentCaptor<ListHoursOfOperationOverridesRequest> listHoursOfOperationOverridesRequestArgumentCaptor = ArgumentCaptor.forClass(ListHoursOfOperationOverridesRequest.class);
+        final ArgumentCaptor<CreateHoursOfOperationOverrideRequest> createHoursOfOperationOverrideRequestArgumentCaptor = ArgumentCaptor.forClass(CreateHoursOfOperationOverrideRequest.class);
+        final ArgumentCaptor<DeleteHoursOfOperationOverrideRequest> deleteHoursOfOperationOverrideRequestArgumentCaptor = ArgumentCaptor.forClass(DeleteHoursOfOperationOverrideRequest.class);
+
+        final UpdateHoursOfOperationResponse updateHoursOfOperationResponse = UpdateHoursOfOperationResponse.builder().build();
+        final CreateHoursOfOperationOverrideResponse createHoursOfOperationOverrideResponse = CreateHoursOfOperationOverrideResponse.builder().build();
+        final DeleteHoursOfOperationOverrideResponse deleteHoursOfOperationOverrideResponse = DeleteHoursOfOperationOverrideResponse.builder().build();
+        final ListHoursOfOperationOverridesResponse listHoursOfOperationOverridesResponse = ListHoursOfOperationOverridesResponse.builder()
+                .hoursOfOperationOverrideList(ImmutableList.of(getHoursOfOperationOverrideThree()))
+                .nextToken(null)
+                .build();
+
+        when(proxyClient.client().updateHoursOfOperation(updateHoursOfOperationRequestArgumentCaptor.capture())).thenReturn(updateHoursOfOperationResponse);
+        when(proxyClient.client().listHoursOfOperationOverrides(listHoursOfOperationOverridesRequestArgumentCaptor.capture())).thenReturn(listHoursOfOperationOverridesResponse);
+        when(proxyClient.client().createHoursOfOperationOverride(createHoursOfOperationOverrideRequestArgumentCaptor.capture())).thenReturn(createHoursOfOperationOverrideResponse);
+        when(proxyClient.client().deleteHoursOfOperationOverride(deleteHoursOfOperationOverrideRequestArgumentCaptor.capture())).thenReturn(deleteHoursOfOperationOverrideResponse);
+
+        ResourceModel previousModel = buildHOOPOverrideDesiredStateResourceModelThree();
+        previousModel.getHoursOfOperationOverrides().get(0).setHoursOfOperationOverrideId(null);
+        ResourceModel desiredModel = buildHOOPOverrideDesiredStateResourceModelThree();
+        // provide a different override id for override-three, rest of the override fields remain the same
+        // this should lead to skipping the api calls since there is essentially no change to HOOP as well
+        // as it's associated overrides.
+        desiredModel.getHoursOfOperationOverrides().get(0).setHoursOfOperationOverrideId("override-four");
+
+        final ResourceHandlerRequest<ResourceModel> request = ResourceHandlerRequest.<ResourceModel>builder()
+                .desiredResourceState(desiredModel)
+                .previousResourceState(previousModel)
+                .build();
+
+        final ProgressEvent<ResourceModel, CallbackContext> response = handler.handleRequest(proxy, request, new CallbackContext(), proxyClient, logger);
+        validateResponse(request, response);
+
+        // Update HOOP
+        verify(proxyClient.client()).updateHoursOfOperation(updateHoursOfOperationRequestArgumentCaptor.capture());
+        assertThat(updateHoursOfOperationRequestArgumentCaptor.getValue().instanceId()).isEqualTo(INSTANCE_ARN);
+        assertThat(updateHoursOfOperationRequestArgumentCaptor.getValue().hoursOfOperationId()).isEqualTo(HOURS_OF_OPERATION_ARN);
+        assertThat(updateHoursOfOperationRequestArgumentCaptor.getValue().name()).isEqualTo(HOURS_OF_OPERATION_NAME_ONE);
+        assertThat(updateHoursOfOperationRequestArgumentCaptor.getValue().description()).isEqualTo(HOURS_OF_OPERATION_DESCRIPTION_ONE);
+        assertThat(updateHoursOfOperationRequestArgumentCaptor.getValue().config()).isNotNull();
+        validateConfig(updateHoursOfOperationRequestArgumentCaptor.getValue().config());
+
+        // override list call
+        verify(proxyClient.client(), times(1)).listHoursOfOperationOverrides(listHoursOfOperationOverridesRequestArgumentCaptor.capture());
+        List<ListHoursOfOperationOverridesRequest> listOverrideRequest = listHoursOfOperationOverridesRequestArgumentCaptor.getAllValues();
+        assertEquals(INSTANCE_ARN, listOverrideRequest.get(0).instanceId());
+        assertEquals(HOURS_OF_OPERATION_ARN, listOverrideRequest.get(0).hoursOfOperationId());
+        assertNull(listOverrideRequest.get(0).nextToken());
+
+        // override create call
+        verify(proxyClient.client(), times(1)).createHoursOfOperationOverride(createHoursOfOperationOverrideRequestArgumentCaptor.capture());
+        CreateHoursOfOperationOverrideRequest createOverrideRequest = createHoursOfOperationOverrideRequestArgumentCaptor.getValue();
+        validateRequest(createOverrideRequest, DAY_ONE, OVERRIDE_TIMESLICE_HOUR_9, OVERRIDE_TIMESLICE_HOUR_13, OVERRIDE_NAME_THREE, HOURS_OF_OPERATION_OVERRIDE_DESCRIPTION);
+
+        verify(proxyClient.client(), times(1)).deleteHoursOfOperationOverride(deleteHoursOfOperationOverrideRequestArgumentCaptor.capture());
+        DeleteHoursOfOperationOverrideRequest overrideDeleteRequest = deleteHoursOfOperationOverrideRequestArgumentCaptor.getValue();
+        assertEquals(INSTANCE_ARN, overrideDeleteRequest.instanceId());
+        assertEquals(HOURS_OF_OPERATION_ARN, overrideDeleteRequest.hoursOfOperationId());
+
+        // No api call for HOOP as well overrides should be made in this case
+        verify(connectClient, times(3)).serviceName();
+    }
+
+    @Test
+    public void testHandleRequestWithEmptyOverrides_Success() {
+        final ArgumentCaptor<UpdateHoursOfOperationRequest> updateHoursOfOperationRequestArgumentCaptor = ArgumentCaptor.forClass(UpdateHoursOfOperationRequest.class);
+        final ArgumentCaptor<ListHoursOfOperationOverridesRequest> listHoursOfOperationOverridesRequestArgumentCaptor = ArgumentCaptor.forClass(ListHoursOfOperationOverridesRequest.class);
+        final ArgumentCaptor<DeleteHoursOfOperationOverrideRequest> deleteHoursOfOperationOverrideRequestArgumentCaptor = ArgumentCaptor.forClass(DeleteHoursOfOperationOverrideRequest.class);
+
+        final UpdateHoursOfOperationResponse updateHoursOfOperationResponse = UpdateHoursOfOperationResponse.builder().build();
+        final ListHoursOfOperationOverridesResponse listHoursOfOperationOverridesResponse = getListHOOPOverridesResponse(null, getHoursOfOperationOverrideTwo());
+        final DeleteHoursOfOperationOverrideResponse deleteHoursOfOperationOverrideResponse = DeleteHoursOfOperationOverrideResponse.builder().build();
+
+        when(proxyClient.client().updateHoursOfOperation(updateHoursOfOperationRequestArgumentCaptor.capture())).thenReturn(updateHoursOfOperationResponse);
+        when(proxyClient.client().listHoursOfOperationOverrides(listHoursOfOperationOverridesRequestArgumentCaptor.capture())).thenReturn(listHoursOfOperationOverridesResponse);
+        when(proxyClient.client().deleteHoursOfOperationOverride(deleteHoursOfOperationOverrideRequestArgumentCaptor.capture())).thenReturn(deleteHoursOfOperationOverrideResponse);
+
+        final ResourceHandlerRequest<ResourceModel> request = ResourceHandlerRequest.<ResourceModel>builder()
+                .desiredResourceState(buildHOOPEmptyOverrideDesiredStateResourceModel())
+                .previousResourceState(buildHOOPOverridePreviousStateResourceModel())
+                .build();
+
+        final ProgressEvent<ResourceModel, CallbackContext> response = handler.handleRequest(proxy, request, new CallbackContext(), proxyClient, logger);
+        validateResponse(request, response);
+
+        verify(proxyClient.client()).updateHoursOfOperation(updateHoursOfOperationRequestArgumentCaptor.capture());
+        assertThat(updateHoursOfOperationRequestArgumentCaptor.getValue().instanceId()).isEqualTo(INSTANCE_ARN);
+        assertThat(updateHoursOfOperationRequestArgumentCaptor.getValue().hoursOfOperationId()).isEqualTo(HOURS_OF_OPERATION_ARN);
+        assertThat(updateHoursOfOperationRequestArgumentCaptor.getValue().name()).isEqualTo(HOURS_OF_OPERATION_NAME_ONE);
+        assertThat(updateHoursOfOperationRequestArgumentCaptor.getValue().description()).isEqualTo(HOURS_OF_OPERATION_DESCRIPTION_ONE);
+        assertThat(updateHoursOfOperationRequestArgumentCaptor.getValue().config()).isNotNull();
+        validateConfig(updateHoursOfOperationRequestArgumentCaptor.getValue().config());
+
+        // override related fields
+        verify(proxyClient.client(), times(1)).listHoursOfOperationOverrides(listHoursOfOperationOverridesRequestArgumentCaptor.capture());
+        ListHoursOfOperationOverridesRequest overrideListRequest = listHoursOfOperationOverridesRequestArgumentCaptor.getValue();
+        assertEquals(INSTANCE_ARN, overrideListRequest.instanceId());
+        assertEquals(HOURS_OF_OPERATION_ARN, overrideListRequest.hoursOfOperationId());
+
+        verify(proxyClient.client()).deleteHoursOfOperationOverride(deleteHoursOfOperationOverrideRequestArgumentCaptor.capture());
+        DeleteHoursOfOperationOverrideRequest overrideDeleteRequest = deleteHoursOfOperationOverrideRequestArgumentCaptor.getValue();
+        assertEquals(INSTANCE_ARN, overrideDeleteRequest.instanceId());
+        assertEquals(HOURS_OF_OPERATION_ARN, overrideDeleteRequest.hoursOfOperationId());
+        verify(connectClient, times(2)).serviceName();
+    }
+
+    @Test
+    public void testHandleRequestWithOverrides_Exception_UpdateHoursOfOperation() {
+        final ArgumentCaptor<UpdateHoursOfOperationRequest> updateHoursOfOperationRequestArgumentCaptor = ArgumentCaptor.forClass(UpdateHoursOfOperationRequest.class);
+        final ArgumentCaptor<ListHoursOfOperationOverridesRequest> listHoursOfOperationOverridesRequestArgumentCaptor = ArgumentCaptor.forClass(ListHoursOfOperationOverridesRequest.class);
+        final ArgumentCaptor<DeleteHoursOfOperationOverrideRequest> deleteHoursOfOperationOverrideRequestArgumentCaptor = ArgumentCaptor.forClass(DeleteHoursOfOperationOverrideRequest.class);
+
+        final UpdateHoursOfOperationResponse updateHoursOfOperationResponse = UpdateHoursOfOperationResponse.builder().build();
+        final ListHoursOfOperationOverridesResponse listHoursOfOperationOverridesResponse = ListHoursOfOperationOverridesResponse.builder().hoursOfOperationOverrideList(getHoursOfOperationOverrideTwo()).build();
+
+        when(proxyClient.client().updateHoursOfOperation(updateHoursOfOperationRequestArgumentCaptor.capture())).thenReturn(updateHoursOfOperationResponse);
+        when(proxyClient.client().listHoursOfOperationOverrides(listHoursOfOperationOverridesRequestArgumentCaptor.capture())).thenReturn(listHoursOfOperationOverridesResponse);
+        when(proxyClient.client().deleteHoursOfOperationOverride(deleteHoursOfOperationOverrideRequestArgumentCaptor.capture())).thenThrow(new RuntimeException());
+
+        final ResourceHandlerRequest<ResourceModel> request = ResourceHandlerRequest.<ResourceModel>builder()
+                .desiredResourceState(buildHOOPEmptyOverrideDesiredStateResourceModel())
+                .previousResourceState(buildHOOPOverridePreviousStateResourceModel())
+                .desiredResourceTags(TAGS_ONE)
+                .previousResourceTags(TAGS_ONE)
+                .build();
+
+        assertThrows(CfnGeneralServiceException.class, () -> handler.handleRequest(proxy, request, new CallbackContext(), proxyClient, logger));
+
+        verify(proxyClient.client()).updateHoursOfOperation(updateHoursOfOperationRequestArgumentCaptor.capture());
+        assertThat(updateHoursOfOperationRequestArgumentCaptor.getValue().instanceId()).isEqualTo(INSTANCE_ARN);
+        assertThat(updateHoursOfOperationRequestArgumentCaptor.getValue().hoursOfOperationId()).isEqualTo(HOURS_OF_OPERATION_ARN);
+        assertThat(updateHoursOfOperationRequestArgumentCaptor.getValue().name()).isEqualTo(HOURS_OF_OPERATION_NAME_ONE);
+        assertThat(updateHoursOfOperationRequestArgumentCaptor.getValue().description()).isEqualTo(HOURS_OF_OPERATION_DESCRIPTION_ONE);
+        assertThat(updateHoursOfOperationRequestArgumentCaptor.getValue().config()).isNotNull();
+        validateConfig(updateHoursOfOperationRequestArgumentCaptor.getValue().config());
+
+        verify(connectClient, times(2)).serviceName();
+    }
+
+    @Test
+    public void testUpdateOverrideWithIdAndNameSwapped() {
+        final ArgumentCaptor<UpdateHoursOfOperationRequest> updateHoursOfOperationRequestArgumentCaptor = ArgumentCaptor.forClass(UpdateHoursOfOperationRequest.class);
+        final ArgumentCaptor<CreateHoursOfOperationOverrideRequest> createHoursOfOperationOverrideRequestArgumentCaptor = ArgumentCaptor.forClass(CreateHoursOfOperationOverrideRequest.class);
+        final ArgumentCaptor<ListHoursOfOperationOverridesRequest> listHoursOfOperationOverridesRequestArgumentCaptor = ArgumentCaptor.forClass(ListHoursOfOperationOverridesRequest.class);
+        final ArgumentCaptor<UpdateHoursOfOperationOverrideRequest> updateHoursOfOperationOverrideRequestArgumentCaptor = ArgumentCaptor.forClass(UpdateHoursOfOperationOverrideRequest.class);
+
+        final UpdateHoursOfOperationResponse updateHoursOfOperationResponse = UpdateHoursOfOperationResponse.builder().build();
+        final ListHoursOfOperationOverridesResponse listHoursOfOperationOverridesResponse = ListHoursOfOperationOverridesResponse.builder()
+                .hoursOfOperationOverrideList(ImmutableList.of(getHoursOfOperationOverrideThree()))
+                .nextToken(null)
+                .build();
+        final CreateHoursOfOperationOverrideResponse createHoursOfOperationOverrideResponse = CreateHoursOfOperationOverrideResponse.builder().build();
+        final UpdateHoursOfOperationOverrideResponse updateHoursOfOperationOverrideResponse = UpdateHoursOfOperationOverrideResponse.builder().build();
+
+        when(proxyClient.client().updateHoursOfOperation(updateHoursOfOperationRequestArgumentCaptor.capture())).thenReturn(updateHoursOfOperationResponse);
+        when(proxyClient.client().listHoursOfOperationOverrides(listHoursOfOperationOverridesRequestArgumentCaptor.capture())).thenReturn(listHoursOfOperationOverridesResponse);
+        when(proxyClient.client().createHoursOfOperationOverride(createHoursOfOperationOverrideRequestArgumentCaptor.capture())).thenReturn(createHoursOfOperationOverrideResponse);
+        when(proxyClient.client().updateHoursOfOperationOverride(updateHoursOfOperationOverrideRequestArgumentCaptor.capture())).thenReturn(updateHoursOfOperationOverrideResponse);
+
+        // we update the description of override-one as part of the desired state
+        ResourceModel previousModel = buildHOOPOverrideDesiredStateResourceModelThree();
+        previousModel.getHoursOfOperationOverrides().get(0).setHoursOfOperationOverrideId(null);
+
+        ResourceModel desiredModel = buildHOOPOverrideDesiredStateResourceModelThree();
+        desiredModel.getHoursOfOperationOverrides().get(0).setOverrideName(OVERRIDE_NAME_ONE);
+        desiredModel.getHoursOfOperationOverrides().add(getOverride(HOURS_OF_OPERATION_OVERRIDE_CONFIG_ONE, null, OVERRIDE_NAME_THREE));
+
+        final ResourceHandlerRequest<ResourceModel> request = ResourceHandlerRequest.<ResourceModel>builder()
+                .desiredResourceState(desiredModel)
+                .previousResourceState(previousModel)
+                .build();
+
+        final ProgressEvent<ResourceModel, CallbackContext> response = handler.handleRequest(proxy, request, new CallbackContext(), proxyClient, logger);
+        validateResponse(request, response);
+
+        // HOOP should be updated
+        verify(proxyClient.client(), times(1)).updateHoursOfOperation(updateHoursOfOperationRequestArgumentCaptor.capture());
+        assertThat(updateHoursOfOperationRequestArgumentCaptor.getValue().instanceId()).isEqualTo(INSTANCE_ARN);
+        assertThat(updateHoursOfOperationRequestArgumentCaptor.getValue().hoursOfOperationId()).isEqualTo(HOURS_OF_OPERATION_ARN);
+        assertThat(updateHoursOfOperationRequestArgumentCaptor.getValue().name()).isEqualTo(HOURS_OF_OPERATION_NAME_ONE);
+        assertThat(updateHoursOfOperationRequestArgumentCaptor.getValue().description()).isEqualTo(HOURS_OF_OPERATION_DESCRIPTION_ONE);
+        assertThat(updateHoursOfOperationRequestArgumentCaptor.getValue().config()).isNotNull();
+        validateConfig(updateHoursOfOperationRequestArgumentCaptor.getValue().config());
+
+        // override list call
+        verify(proxyClient.client(), times(1)).listHoursOfOperationOverrides(listHoursOfOperationOverridesRequestArgumentCaptor.capture());
+        List<ListHoursOfOperationOverridesRequest> listOverrideRequest = listHoursOfOperationOverridesRequestArgumentCaptor.getAllValues();
+        assertEquals(INSTANCE_ARN, listOverrideRequest.get(0).instanceId());
+        assertEquals(HOURS_OF_OPERATION_ARN, listOverrideRequest.get(0).hoursOfOperationId());
+
+        // a new override will be created with name as OVERRIDE_NAME_THREE
+        verify(proxyClient.client(), times(1)).createHoursOfOperationOverride(createHoursOfOperationOverrideRequestArgumentCaptor.capture());
+        CreateHoursOfOperationOverrideRequest createOverrideRequest = createHoursOfOperationOverrideRequestArgumentCaptor.getValue();
+        validateRequest(createOverrideRequest, TUESDAY, OVERRIDE_TIMESLICE_HOUR_9, OVERRIDE_TIMESLICE_HOUR_17, OVERRIDE_NAME_THREE, HOURS_OF_OPERATION_OVERRIDE_DESCRIPTION);
+
+        // override with id HOURS_OF_OPERATION_OVERRIDE_ID_THREE will be updated with name changed to OVERRIDE_NAME_ONE
+        verify(proxyClient.client(), times(1)).updateHoursOfOperationOverride(any(UpdateHoursOfOperationOverrideRequest.class));
+        UpdateHoursOfOperationOverrideRequest overrideUpdateRequest = updateHoursOfOperationOverrideRequestArgumentCaptor.getValue();
+        validateUpdateOverrideRequest(overrideUpdateRequest, HOURS_OF_OPERATION_OVERRIDE_ID_THREE, DAY_ONE, OVERRIDE_TIMESLICE_HOUR_9, OVERRIDE_TIMESLICE_HOUR_13, OVERRIDE_NAME_ONE, HOURS_OF_OPERATION_OVERRIDE_DESCRIPTION);
+
+        // Delete api will not be invoked.
+        verify(proxyClient.client(), never()).deleteHoursOfOperationOverride(any(DeleteHoursOfOperationOverrideRequest.class));
+
+        verify(connectClient, times(3)).serviceName();
+    }
+
+    @Test
+    public void testHandleRequest_NullOverrides() {
+        final ArgumentCaptor<UpdateHoursOfOperationRequest> updateHoursOfOperationRequestArgumentCaptor = ArgumentCaptor.forClass(UpdateHoursOfOperationRequest.class);
+        final UpdateHoursOfOperationResponse updateHoursOfOperationResponse = UpdateHoursOfOperationResponse.builder().build();
+
+        when(proxyClient.client().updateHoursOfOperation(updateHoursOfOperationRequestArgumentCaptor.capture())).thenReturn(updateHoursOfOperationResponse);
+
+        ResourceModel desiredModel = buildHOOPEmptyOverrideDesiredStateResourceModel();
+        desiredModel.setHoursOfOperationOverrides(null);
+        final ResourceHandlerRequest<ResourceModel> request = ResourceHandlerRequest.<ResourceModel>builder()
+                .desiredResourceState(desiredModel)
+                .previousResourceState(buildHOOPOverridePreviousStateResourceModel())
+                .build();
+
+        final ProgressEvent<ResourceModel, CallbackContext> response = handler.handleRequest(proxy, request, new CallbackContext(), proxyClient, logger);
+        validateResponse(request, response);
+
+        verify(proxyClient.client()).updateHoursOfOperation(updateHoursOfOperationRequestArgumentCaptor.capture());
+        assertThat(updateHoursOfOperationRequestArgumentCaptor.getValue().instanceId()).isEqualTo(INSTANCE_ARN);
+        assertThat(updateHoursOfOperationRequestArgumentCaptor.getValue().hoursOfOperationId()).isEqualTo(HOURS_OF_OPERATION_ARN);
+        assertThat(updateHoursOfOperationRequestArgumentCaptor.getValue().name()).isEqualTo(HOURS_OF_OPERATION_NAME_ONE);
+        assertThat(updateHoursOfOperationRequestArgumentCaptor.getValue().description()).isEqualTo(HOURS_OF_OPERATION_DESCRIPTION_ONE);
+        assertThat(updateHoursOfOperationRequestArgumentCaptor.getValue().config()).isNotNull();
+        validateConfig(updateHoursOfOperationRequestArgumentCaptor.getValue().config());
+
+        // Update and Delete override apis should not be called.
+        verify(proxyClient.client(), never()).createHoursOfOperationOverride(any(CreateHoursOfOperationOverrideRequest.class));
+        verify(proxyClient.client(), never()).updateHoursOfOperationOverride(any(UpdateHoursOfOperationOverrideRequest.class));
+
+        verify(connectClient, times(1)).serviceName();
+    }
+
+    private void validateRequest(CreateHoursOfOperationOverrideRequest createOverrideRequest, String day, Integer startTime, Integer endTime, String overrideName, String description) {
+        assertEquals(description, createOverrideRequest.description());
+        assertEquals(overrideName, createOverrideRequest.name());
+        assertEquals(OVERRIDE_EFFECTIVE_FROM, createOverrideRequest.effectiveFrom());
+        assertEquals(OVERRIDE_EFFECTIVE_TILL, createOverrideRequest.effectiveTill());
+        assertNotNull(createOverrideRequest.config());
+        assertEquals(1, createOverrideRequest.config().size());
+        assertEquals(OverrideDays.fromValue(day), createOverrideRequest.config().get(0).day());
+        assertEquals(startTime, createOverrideRequest.config().get(0).startTime().hours());
+        assertEquals(OVERRIDE_TIMESLICE_MIN_0, createOverrideRequest.config().get(0).startTime().minutes());
+        assertEquals(endTime, createOverrideRequest.config().get(0).endTime().hours());
+        assertEquals(OVERRIDE_TIMESLICE_MIN_0, createOverrideRequest.config().get(0).endTime().minutes());
+    }
+
+    private void validateUpdateOverrideRequest(UpdateHoursOfOperationOverrideRequest updateOverrideRequest, String overrideId, String day, Integer startTime, Integer endTime, String overrideName, String description) {
+        assertEquals(description, updateOverrideRequest.description());
+        assertEquals(overrideId, updateOverrideRequest.hoursOfOperationOverrideId());
+        assertEquals(overrideName, updateOverrideRequest.name());
+        assertEquals(OVERRIDE_EFFECTIVE_FROM, updateOverrideRequest.effectiveFrom());
+        assertEquals(OVERRIDE_EFFECTIVE_TILL, updateOverrideRequest.effectiveTill());
+        assertNotNull(updateOverrideRequest.config());
+        assertEquals(1, updateOverrideRequest.config().size());
+        assertEquals(OverrideDays.fromValue(day), updateOverrideRequest.config().get(0).day());
+        assertEquals(startTime, updateOverrideRequest.config().get(0).startTime().hours());
+        assertEquals(OVERRIDE_TIMESLICE_MIN_0, updateOverrideRequest.config().get(0).startTime().minutes());
+        assertEquals(endTime, updateOverrideRequest.config().get(0).endTime().hours());
+        assertEquals(OVERRIDE_TIMESLICE_MIN_0, updateOverrideRequest.config().get(0).endTime().minutes());
+    }
+
+    private void validateResponse(ResourceHandlerRequest<ResourceModel> request, ProgressEvent<ResourceModel, CallbackContext> response) {
+        assertThat(response).isNotNull();
+        assertThat(response.getStatus()).isEqualTo(OperationStatus.SUCCESS);
+        assertThat(response.getCallbackContext()).isNull();
+        assertThat(response.getCallbackDelaySeconds()).isEqualTo(0);
+        assertThat(response.getResourceModel()).isEqualTo(request.getDesiredResourceState());
+        assertThat(response.getResourceModels()).isNull();
+        assertThat(response.getMessage()).isNull();
+        assertThat(response.getErrorCode()).isNull();
     }
 }


### PR DESCRIPTION
*Issue #, if available:* We launched CloudFormation support for Overrides which are entity of HoursOfOperation. Creating merge request to update existing HoursOfOperation handlers to include override functionality.

*Description of changes:*
1. Change include updated HoursOfOperation handlers to support create and update of overrides. The current HoursOfOperation schema is also modified to include overrides attributes.
2. Canary, Integration and contract tests are also updated for override feature


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
